### PR TITLE
Coupled tica

### DIFF
--- a/include_rt_kernels/gas_optics_rrtmgp_kernels_cuda_rt.h
+++ b/include_rt_kernels/gas_optics_rrtmgp_kernels_cuda_rt.h
@@ -33,14 +33,15 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
     void reorder123x321(const int ni, const int nj, const int nk,
             const Float* arr_in, Float* arr_out);
 
-    
+
     void reorder12x21(const int ni, const int nj, const Float* arr_in, Float* arr_out);
 
-    
+
     void zero_array(const int ni, const int nj, const int nk, const int nn, Float* arr);
     void zero_array(const int ni, const int nj, const int nk, Float* arr);
     void zero_array(const int ni, const int nj, Float* arr);
     void zero_array(const int ni, int* arr);
+    void zero_array(const int ni, Float* arr);
 
 
     void interpolation(

--- a/include_tilt/tilt_utils.h
+++ b/include_tilt/tilt_utils.h
@@ -192,13 +192,29 @@ void tica_tilt_simple(const int n_col_x, const int n_col_y, const int n_col,
 void tica_tilt_gpu(const Float sza, const Float azi,
     const int n_col_x, const int n_col_y, const int n_col,
     const int n_lay, const int n_lev, const int n_z_in, const int n_zh_in ,
-    Array<Float,1>& xh, Array<Float,1>& yh, Array<Float,1>& zh, Array<Float,1>& z,
+    const Array_gpu<Float,1>& z, const Array_gpu<Float,1>& zh,
     Array_gpu<Float,2>& p_lay, Array_gpu<Float,2>& t_lay, Array_gpu<Float,2>& p_lev, Array_gpu<Float,2>& t_lev,
     Array_gpu<Float,2>& lwp, Array_gpu<Float,2>& iwp, Array_gpu<Float,2>& rel, Array_gpu<Float,2>& dei, Array_gpu<Float,2>& rh,
+    const Array_gpu<ijk,1>& tilted_path, const Array_gpu<int,1>& tilted_path_bounds,
+    const Array_gpu<Float,1>& zh_tilt, Array_gpu<Float,1>& p_lev_tilt,
     Gas_concs_gpu& gas_concs, Aerosol_concs_gpu& aerosol_concs,
     std::vector<std::string>& gas_names, std::vector<std::string>& aerosol_names,
     bool switch_cloud_optics, bool switch_liq_cloud_optics, bool switch_ice_cloud_optics, bool switch_aerosol_optics,
     int rnd_seed);
+
+void tica_reverse_gpu(
+        const int n_col_x, const int n_col_y, const int n_lay, const int n_lev,
+        const int n_z, const int n_z_in, const int n_zh_in ,
+        const bool do_tilting, const bool switch_twostream, const bool switch_raytracing,
+        const Array_gpu<Float,1>& zh, const Array_gpu<Float,1>& zh_tilt,
+        const Array_gpu<ijk,1>& tilted_path, const Array_gpu<int,1>& tilted_path_bounds,
+        const Array_gpu<Float,1>& p_lev_tilt,
+        const Array_gpu<Float,2>& sw_flux_dn_tilt, const Array_gpu<Float,2>& sw_flux_dn_dir_tilt,
+        const Array_gpu<Float,2>& sw_flux_up_tilt, const Array_gpu<Float,2>& sw_flux_net_tilt,
+        const Array_gpu<Float,3>& rt_flux_abs_dir_tilt, const Array_gpu<Float,3>& rt_flux_abs_dif_tilt, const Array_gpu<Float,2>& rt_flux_tod_up_tilt,
+        Array_gpu<Float,2>& sw_flux_dn, Array_gpu<Float,2>& sw_flux_dn_dir,
+        Array_gpu<Float,2>& sw_flux_up, Array_gpu<Float,2>& sw_flux_net,
+        Array_gpu<Float,3>& rt_flux_abs_dir, Array_gpu<Float,3>& rt_flux_abs_dif, Array_gpu<Float,2>& rt_flux_tod_up);
 
     // // esat and qsat functions taken from microHH (https://github.com/microhh/microhh)
     __host__ __device__

--- a/include_tilt/tilt_utils.h
+++ b/include_tilt/tilt_utils.h
@@ -205,7 +205,7 @@ void tica_tilt_gpu(const Float sza, const Float azi,
 void tica_reverse_gpu(
         const int n_col_x, const int n_col_y, const int n_lay, const int n_lev,
         const int n_z, const int n_z_in, const int n_zh_in ,
-        const bool do_tilting, const bool switch_twostream, const bool switch_raytracing,
+        const bool switch_twostream, const bool switch_raytracing,
         const Array_gpu<Float,1>& zh, const Array_gpu<Float,1>& zh_tilt,
         const Array_gpu<ijk,1>& tilted_path, const Array_gpu<int,1>& tilted_path_bounds,
         const Array_gpu<Float,1>& p_lev_tilt,

--- a/include_tilt/tilt_utils.h
+++ b/include_tilt/tilt_utils.h
@@ -1,3 +1,6 @@
+#ifndef TILTED_COLUMN_H
+#define TILTED_COLUMN_H
+
 #include <cmath>
 #include <chrono>
 #include <iomanip>
@@ -34,6 +37,10 @@ void create_tilted_path(const std::vector<Float>& xh, const std::vector<Float>& 
         const Float x_start, const Float y_start,
         std::vector<ijk>& tilted_path,
         std::vector<Float>& zh_tilted);
+
+void get_tilted_path_bounds(const int n_z_tilt,
+                const std::vector<ijk>& tilted_path,
+                std::vector<int>& tilted_path_bounds);
 
 void post_process_output(const std::vector<ColumnResult>& col_results,
         const int n_col_x, const int n_col_y,
@@ -177,3 +184,62 @@ void tica_tilt_simple(const int n_col_x, const int n_col_y, const int n_col,
                       std::vector<std::string>& gas_names, std::vector<std::string>& aerosol_names,
                       bool switch_cloud_optics, bool switch_liq_cloud_optics, bool switch_ice_cloud_optics, bool switch_aerosol_optics,
                       Array<ijk,1> center_path, Array<Float,1> center_zh_tilt, const int n_z_tilt_center);
+
+
+
+#ifdef __CUDACC__
+/// GPU functions
+void tica_tilt_gpu(const Float sza, const Float azi,
+    const int n_col_x, const int n_col_y, const int n_col,
+    const int n_lay, const int n_lev, const int n_z_in, const int n_zh_in ,
+    Array<Float,1>& xh, Array<Float,1>& yh, Array<Float,1>& zh, Array<Float,1>& z,
+    Array_gpu<Float,2>& p_lay, Array_gpu<Float,2>& t_lay, Array_gpu<Float,2>& p_lev, Array_gpu<Float,2>& t_lev,
+    Array_gpu<Float,2>& lwp, Array_gpu<Float,2>& iwp, Array_gpu<Float,2>& rel, Array_gpu<Float,2>& dei, Array_gpu<Float,2>& rh,
+    Gas_concs_gpu& gas_concs, Aerosol_concs_gpu& aerosol_concs,
+    std::vector<std::string>& gas_names, std::vector<std::string>& aerosol_names,
+    bool switch_cloud_optics, bool switch_liq_cloud_optics, bool switch_ice_cloud_optics, bool switch_aerosol_optics,
+    int rnd_seed);
+
+    // // esat and qsat functions taken from microHH
+    __host__ __device__
+    inline Float esat_liq(const Float T)
+    {
+        constexpr Float c00  = Float(+6.1121000000E+02);
+        constexpr Float c10  = Float(+4.4393067270E+01);
+        constexpr Float c20  = Float(+1.4279398448E+00);
+        constexpr Float c30  = Float(+2.6415206946E-02);
+        constexpr Float c40  = Float(+3.0291749160E-04);
+        constexpr Float c50  = Float(+2.1159987257E-06);
+        constexpr Float c60  = Float(+7.5015702516E-09);
+        constexpr Float c70  = Float(-1.5604873363E-12);
+        constexpr Float c80  = Float(-9.9726710231E-14);
+        constexpr Float c90  = Float(-4.8165754883E-17);
+        constexpr Float c100 = Float(+1.3839187032E-18);
+
+        const Float x = min(max(Float(-75.), T-Float(273.16)), Float(50.));       // Limit the temperature range to avoid numerical errors
+        return c00+x*(c10+x*(c20+x*(c30+x*(c40+x*(c50+x*(c60+x*(c70+x*(c80+x*(c90+x*c100)))))))));
+    }
+
+    __host__ __device__
+    inline Float qsat_liq(const Float p, const Float T)
+    {
+        constexpr Float ep = Float(0.219718);
+        return ep*esat_liq(T)/(p-(Float(1.)-ep)*esat_liq(T));
+    }
+
+    __host__ __device__
+    inline Float esat_ice(const Float T)
+    {
+        const Float x= min(max(Float(-100.), T-Float(273.16)), Float(50.));     // Limit the temperature range to avoid numerical errors
+        return Float(611.15)*exp(Float(22.452)*x / (Float(272.55)+x));
+    }
+
+    __host__ __device__
+    inline Float qsat_ice(const Float p, const Float T)
+    {
+        constexpr Float ep = Float(0.219718);
+        return ep*esat_ice(T)/(p-(Float(1.)-ep)*esat_ice(T));
+    }
+#endif
+
+#endif

--- a/include_tilt/tilt_utils.h
+++ b/include_tilt/tilt_utils.h
@@ -200,7 +200,7 @@ void tica_tilt_gpu(const Float sza, const Float azi,
     bool switch_cloud_optics, bool switch_liq_cloud_optics, bool switch_ice_cloud_optics, bool switch_aerosol_optics,
     int rnd_seed);
 
-    // // esat and qsat functions taken from microHH
+    // // esat and qsat functions taken from microHH (https://github.com/microhh/microhh)
     __host__ __device__
     inline Float esat_liq(const Float T)
     {
@@ -216,28 +216,28 @@ void tica_tilt_gpu(const Float sza, const Float azi,
         constexpr Float c90  = Float(-4.8165754883E-17);
         constexpr Float c100 = Float(+1.3839187032E-18);
 
-        const Float x = min(max(Float(-75.), T-Float(273.16)), Float(50.));       // Limit the temperature range to avoid numerical errors
+        const Float x = min(max(Float(-75.), T-Float(273.15)), Float(50.));       // Limit the temperature range to avoid numerical errors
         return c00+x*(c10+x*(c20+x*(c30+x*(c40+x*(c50+x*(c60+x*(c70+x*(c80+x*(c90+x*c100)))))))));
     }
 
     __host__ __device__
     inline Float qsat_liq(const Float p, const Float T)
     {
-        constexpr Float ep = Float(0.219718);
+        constexpr Float ep = Float(0.6219718);
         return ep*esat_liq(T)/(p-(Float(1.)-ep)*esat_liq(T));
     }
 
     __host__ __device__
     inline Float esat_ice(const Float T)
     {
-        const Float x= min(max(Float(-100.), T-Float(273.16)), Float(50.));     // Limit the temperature range to avoid numerical errors
+        const Float x= min(max(Float(-100.), T-Float(273.15)), Float(50.));     // Limit the temperature range to avoid numerical errors
         return Float(611.15)*exp(Float(22.452)*x / (Float(272.55)+x));
     }
 
     __host__ __device__
     inline Float qsat_ice(const Float p, const Float T)
     {
-        constexpr Float ep = Float(0.219718);
+        constexpr Float ep = Float(0.6219718);
         return ep*esat_ice(T)/(p-(Float(1.)-ep)*esat_ice(T));
     }
 #endif

--- a/include_tilt/tilt_utils.h
+++ b/include_tilt/tilt_utils.h
@@ -28,10 +28,10 @@ inline int sign(Float value)
     return (Float(0.) < value) - (value < Float(0.));
 }
 
-void tilted_path(std::vector<Float>& xh, std::vector<Float>& yh,
-        std::vector<Float>& zh, std::vector<Float>& z,
-        Float sza, Float azi,
-        Float x_start, Float y_start,
+void create_tilted_path(const std::vector<Float>& xh, const std::vector<Float>& yh,
+        const std::vector<Float>& zh, const std::vector<Float>& z,
+        const Float sza, const Float azi,
+        const Float x_start, const Float y_start,
         std::vector<ijk>& tilted_path,
         std::vector<Float>& zh_tilted);
 
@@ -84,8 +84,8 @@ void tilt_and_compress_fields(const int n_z_in, const int n_zh_in, const int n_c
     const int n_z_tilt, const int n_zh_tilt, const int n_col,
     const Array<Float,1>& zh, const Array<Float,1>& z,
     const Array<Float,1>& zh_tilt, const Array<ijk,1>& path,
-    Array<Float,2>* p_lay_copy, Array<Float,2>* t_lay_copy, Array<Float,2>* p_lev_copy, Array<Float,2>* t_lev_copy, 
-    Array<Float,2>* rh_copy, 
+    Array<Float,2>* p_lay_copy, Array<Float,2>* t_lay_copy, Array<Float,2>* p_lev_copy, Array<Float,2>* t_lev_copy,
+    Array<Float,2>* rh_copy,
     Gas_concs& gas_concs_copy, const std::vector<std::string>& gas_names,
     Aerosol_concs& aerosol_concs_copy, const std::vector<std::string>& aerosol_names, const bool switch_aerosol_optics
     );

--- a/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_launchers_rt.cu
+++ b/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_launchers_rt.cu
@@ -123,6 +123,19 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
 
     }
 
+    void zero_array(const int ni, Float* arr)
+    {
+        const int block_i = 32;
+
+        const int grid_i = ni/block_i + (ni%block_i > 0);
+
+        dim3 grid_gpu(grid_i);
+        dim3 block_gpu(block_i);
+
+        zero_array_kernel<<<grid_gpu, block_gpu>>>(
+                ni, arr);
+    }
+
     void zero_array(const int ni, int* arr)
     {
         const int block_i = 32;

--- a/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_rt.cu
+++ b/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_rt.cu
@@ -160,6 +160,20 @@ void zero_array_kernel(
 __global__
 void zero_array_kernel(
         const int ni,
+        Float* __restrict__ arr)
+{
+    const int ii = blockIdx.x*blockDim.x + threadIdx.x;
+
+    if ( (ii < ni) )
+    {
+        const int idx = ii;
+        arr[idx] = Float(0.);
+    }
+}
+
+__global__
+void zero_array_kernel(
+        const int ni,
         int* __restrict__ arr)
 {
     const int ii = blockIdx.x*blockDim.x + threadIdx.x;

--- a/src_test/CMakeLists.txt
+++ b/src_test/CMakeLists.txt
@@ -25,12 +25,12 @@ message(STATUS "Git hash " ${GITHASH})
 add_definitions(-DGITHASH="${GITHASH}")
 
 if(USECUDA)
-  add_executable(test_rte_rrtmgp_gpu Radiation_solver.cu test_rte_rrtmgp.cu ../src_tilt/tilt_utils.cpp)
-  target_link_libraries(test_rte_rrtmgp_gpu rte_rrtmgp rte_rrtmgp_cuda ${LIBS} m)
-  
-  add_executable(test_rte_rrtmgp_rt_gpu Radiation_solver_rt.cu test_rte_rrtmgp_rt.cu ../src_tilt/tilt_utils.cpp)
-  target_link_libraries(test_rte_rrtmgp_rt_gpu rte_rrtmgp rte_rrtmgp_cuda rte_rrtmgp_cuda_rt curand ${LIBS} m)
-  
+  add_executable(test_rte_rrtmgp_gpu Radiation_solver.cu test_rte_rrtmgp.cu)
+  target_link_libraries(test_rte_rrtmgp_gpu rte_rrtmgp rte_rrtmgp_cuda rte_rrtmgp_tilt ${LIBS} m)
+
+  add_executable(test_rte_rrtmgp_rt_gpu Radiation_solver_rt.cu test_rte_rrtmgp_rt.cu)
+  target_link_libraries(test_rte_rrtmgp_rt_gpu rte_rrtmgp rte_rrtmgp_cuda rte_rrtmgp_cuda_rt rte_rrtmgp_tilt curand ${LIBS} m)
+
   add_executable(test_rte_rrtmgp_bw_gpu Radiation_solver_bw.cu test_rte_rrtmgp_bw.cu)
   target_link_libraries(test_rte_rrtmgp_bw_gpu rte_rrtmgp rte_rrtmgp_cuda rte_rrtmgp_cuda_rt curand ${LIBS} m)
 

--- a/src_test/test_rte_rrtmgp.cu
+++ b/src_test/test_rte_rrtmgp.cu
@@ -275,6 +275,21 @@ void solve_radiation(int argc, char** argv)
     Array<Float,2> p_lev(input_nc.get_variable<Float>("p_lev", {n_lev, n_col_y, n_col_x}), {n_col, n_lev});
     Array<Float,2> t_lev(input_nc.get_variable<Float>("t_lev", {n_lev, n_col_y, n_col_x}), {n_col, n_lev});
 
+    // If T_lev is empty but needed (e.g. LW or tilted columns), interpolate from T_lay
+    if (switch_longwave || switch_tica)
+    {
+        if (*std::max_element(t_lev.v().begin(), t_lev.v().end()) <= 0)
+        {
+            for (int i = 1; i <= n_col; ++i) {
+                for (int j = 2; j <= n_lay; ++j) {
+                    t_lev({i, j}) = (t_lay({i, j}) + t_lay({i, j - 1})) / 2.0;
+                }
+                t_lev({i, n_lev}) = 2 * t_lay({i, n_lay}) - t_lev({i,n_lay});
+                t_lev({i, 1}) = 2 * t_lay({i, 1}) - t_lev({i,2});
+            }
+        }
+    }
+
     if (input_nc.variable_exists("col_dry") && switch_tica)
     {
         std::string error = "col_dry is not supported in tica mode";

--- a/src_test/test_rte_rrtmgp.cu
+++ b/src_test/test_rte_rrtmgp.cu
@@ -411,7 +411,7 @@ void solve_radiation(int argc, char** argv)
         tica_sza = acos(mu0.v()[0]);
         tica_azi = azi.v()[0];
 
-        tilted_path(xh.v(),yh.v(),zh.v(),z.v(),tica_sza, tica_azi, 0.5, 0.5, center_path.v(), center_zh_tilt.v());
+        create_tilted_path(xh.v(),yh.v(),zh.v(),z.v(),tica_sza, tica_azi, 0.5, 0.5, center_path.v(), center_zh_tilt.v());
 
         int n_zh_tilt_center = center_zh_tilt.v().size();
         int n_z_tilt_center = n_zh_tilt_center - 1;

--- a/src_test/test_rte_rrtmgp_rt.cu
+++ b/src_test/test_rte_rrtmgp_rt.cu
@@ -544,61 +544,18 @@ void solve_radiation(int argc, char** argv)
             azi({icol}) = 0.0;
         }
 
-        Array<Float, 2> t_lay_out = t_lay;
-        Array<Float, 2> t_lev_out = t_lev;
-        Array<Float, 2> p_lay_out = p_lay;
-        Array<Float, 2> p_lev_out = p_lev;
-        Gas_concs gas_concs_out = gas_concs;
-        Aerosol_concs aerosol_concs_out = aerosol_concs;
-        Array<Float, 2> rh_out = rh;
-
-        Array<Float, 2> lwp_out;
-        lwp_out.set_dims({n_col, n_z_in});
-        Array<Float, 2> rel_out;
-        rel_out.set_dims({n_col, n_z_in});
-        Array<Float, 2> iwp_out;
-        iwp_out.set_dims({n_col, n_z_in});
-        Array<Float, 2> dei_out;
-        dei_out.set_dims({n_col, n_z_in});
-
-        tica_tilt(
+        tica_tilt_gpu(
                 tica_sza, tica_azi,
                 n_col_x, n_col_y, n_col,
                 n_lay, n_lev, n_z_in, n_zh_in,
                 xh, yh, zh, z,
-                p_lay, t_lay, p_lev, t_lev,
-                lwp, iwp, rel, dei, rh,
-                gas_concs, aerosol_concs,
-                p_lay_out, t_lay_out, p_lev_out, t_lev_out,
-                lwp_out, iwp_out, rel_out, dei_out, rh_out,
-                gas_concs_out, aerosol_concs_out,
+                p_lay_gpu, t_lay_gpu, p_lev_gpu, t_lev_gpu,
+                lwp_gpu, iwp_gpu, rel_gpu, dei_gpu, rh_gpu,
+                gas_concs_gpu, aerosol_concs_gpu,
                 gas_names, aerosol_names,
                 switch_cloud_optics, switch_liq_cloud_optics, switch_ice_cloud_optics, switch_aerosol_optics,
                 rnd_seed
         );
-
-        lwp_out.expand_dims({n_col, n_lay});
-        rel_out.expand_dims({n_col, n_lay});
-        iwp_out.expand_dims({n_col, n_lay});
-        dei_out.expand_dims({n_col, n_lay});
-
-        if (switch_aerosol_optics)
-        {
-            rh_out.expand_dims({n_col, n_lay});
-            rh  = rh_out;
-            aerosol_concs = aerosol_concs_out;
-        }
-
-        lwp = lwp_out;
-        rel = rel_out;
-        iwp = iwp_out;
-        dei = dei_out;
-
-        p_lay = p_lay_out;
-        p_lev = p_lev_out;
-        t_lay = t_lay_out;
-        t_lev = t_lev_out;
-        gas_concs = gas_concs_out;
 
         Status::print_message("tilted path created");
         cudaEventRecord(stop, 0);
@@ -663,8 +620,6 @@ void solve_radiation(int argc, char** argv)
         // Initialize the solver.
         Status::print_message("Initializing the longwave solver.");
 
-        Gas_concs_gpu gas_concs_gpu(gas_concs);
-
         Radiation_solver_longwave rad_lw(gas_concs_gpu, "coefficients_lw.nc", "cloud_coefficients_lw.nc");
 
         // Read the boundary conditions.
@@ -719,18 +674,9 @@ void solve_radiation(int argc, char** argv)
 
         auto run_solver = [&]()
         {
-            Array_gpu<Float,2> p_lay_gpu(p_lay);
-            Array_gpu<Float,2> p_lev_gpu(p_lev);
-            Array_gpu<Float,2> t_lay_gpu(t_lay);
-            Array_gpu<Float,2> t_lev_gpu(t_lev);
             Array_gpu<Float,2> col_dry_gpu(col_dry);
             Array_gpu<Float,1> t_sfc_gpu(t_sfc);
             Array_gpu<Float,2> emis_sfc_gpu(emis_sfc);
-            Array_gpu<Float,2> lwp_gpu(lwp);
-            Array_gpu<Float,2> iwp_gpu(iwp);
-            Array_gpu<Float,2> rel_gpu(rel);
-            Array_gpu<Float,2> dei_gpu(dei);
-
 
             cudaDeviceSynchronize();
             cudaEvent_t start;
@@ -851,8 +797,6 @@ void solve_radiation(int argc, char** argv)
         // Initialize the solver.
         Status::print_message("Initializing the shortwave solver.");
 
-
-        Gas_concs_gpu gas_concs_gpu(gas_concs);
         Radiation_solver_shortwave rad_sw(gas_concs_gpu, "coefficients_sw.nc", "cloud_coefficients_sw.nc", "aerosol_optics.nc");
 
         // Read the boundary conditions.
@@ -973,10 +917,6 @@ void solve_radiation(int argc, char** argv)
 
         auto run_solver = [&]()
         {
-            Array_gpu<Float,2> p_lay_gpu(p_lay);
-            Array_gpu<Float,2> p_lev_gpu(p_lev);
-            Array_gpu<Float,2> t_lay_gpu(t_lay);
-            Array_gpu<Float,2> t_lev_gpu(t_lev);
             Array_gpu<Float,2> col_dry_gpu(col_dry);
             Array_gpu<Float,2> sfc_alb_dir_gpu(sfc_alb_dir);
             Array_gpu<Float,2> sfc_alb_dif_gpu(sfc_alb_dif);
@@ -984,13 +924,6 @@ void solve_radiation(int argc, char** argv)
             Array_gpu<Float,1> tica_scaling_gpu(tica_scaling);
             Array_gpu<Float,1> mu0_gpu(mu0);
             Array_gpu<Float,1> azi_gpu(azi);
-            Array_gpu<Float,2> lwp_gpu(lwp);
-            Array_gpu<Float,2> iwp_gpu(iwp);
-            Array_gpu<Float,2> rel_gpu(rel);
-            Array_gpu<Float,2> dei_gpu(dei);
-
-            Array_gpu<Float,2> rh_gpu(rh);
-            Aerosol_concs_gpu aerosol_concs_gpu(aerosol_concs);
 
             cudaDeviceSynchronize();
             cudaEvent_t start;
@@ -1028,7 +961,7 @@ void solve_radiation(int argc, char** argv)
                     mu0_gpu, azi_gpu,
                     lwp_gpu, iwp_gpu,
                     rel_gpu, dei_gpu,
-                    rh,
+                    rh_gpu,
                     aerosol_concs_gpu,
                     sw_tot_tau, sw_tot_ssa,
                     sw_cld_tau, sw_cld_ssa, sw_cld_asy,

--- a/src_test/test_rte_rrtmgp_rt.cu
+++ b/src_test/test_rte_rrtmgp_rt.cu
@@ -358,8 +358,21 @@ void solve_radiation(int argc, char** argv)
     Array<Float,2> p_lev(input_nc.get_variable<Float>("p_lev", {n_lev, n_col_y, n_col_x}), {n_col, n_lev});
     Array<Float,2> t_lev(input_nc.get_variable<Float>("t_lev", {n_lev, n_col_y, n_col_x}), {n_col, n_lev});
 
-    
-    
+    // If T_lev is empty but needed (e.g. LW or tilted columns), interpolate from T_lay
+    if (switch_longwave || switch_tica)
+    {
+        if (*std::max_element(t_lev.v().begin(), t_lev.v().end()) <= 0)
+        {
+            for (int i = 1; i <= n_col; ++i) {
+                for (int j = 2; j <= n_lay; ++j) {
+                    t_lev({i, j}) = (t_lay({i, j}) + t_lay({i, j - 1})) / 2.0;
+                }
+                t_lev({i, n_lev}) = 2 * t_lay({i, n_lay}) - t_lev({i,n_lay});
+                t_lev({i, 1}) = 2 * t_lay({i, 1}) - t_lev({i,2});
+            }
+        }
+    }
+
     if (input_nc.variable_exists("col_dry") && switch_tica)
     {
         std::string error = "col_dry is not supported in tica mode";
@@ -472,6 +485,19 @@ void solve_radiation(int argc, char** argv)
     bool do_tilting = false;
     if (switch_tica && mu0.v()[0] > 0.087)     // mu0 = 0.087 roughly corresponds to a sza of 85 degrees
         do_tilting = true;
+
+    Array_gpu<Float,2> p_lay_gpu(p_lay);
+    Array_gpu<Float,2> p_lev_gpu(p_lev);
+    Array_gpu<Float,2> t_lay_gpu(t_lay);
+    Array_gpu<Float,2> t_lev_gpu(t_lev);
+    Array_gpu<Float,2> lwp_gpu(lwp);
+    Array_gpu<Float,2> iwp_gpu(iwp);
+    Array_gpu<Float,2> rel_gpu(rel);
+    Array_gpu<Float,2> dei_gpu(dei);
+    Array_gpu<Float,2> rh_gpu(rh);
+
+    Gas_concs_gpu gas_concs_gpu(gas_concs);
+    Aerosol_concs_gpu aerosol_concs_gpu(aerosol_concs);
 
     if (do_tilting)
     {

--- a/src_test/test_rte_rrtmgp_rt.cu
+++ b/src_test/test_rte_rrtmgp_rt.cu
@@ -345,6 +345,7 @@ void solve_radiation(int argc, char** argv)
     Array<Float,1> grid_y(input_nc.get_variable<Float>("y", {n_col_y}), {n_col_y});
     Array<Float,1> grid_yh(input_nc.get_variable<Float>("yh", {n_col_y+1}), {n_col_y+1});
     Array<Float,1> grid_z(input_nc.get_variable<Float>("z", {n_z_in}), {n_z_in});
+    Array<Float,1> grid_zh(input_nc.get_variable<Float>("zh", {n_zh_in}), {n_zh_in});
 
     const Vector<int> grid_cells = {n_col_x, n_col_y, n_z};
     const Vector<Float> grid_d = {grid_xh({2}) - grid_xh({1}), grid_yh({2}) - grid_yh({1}), grid_z({2}) - grid_z({1})};
@@ -475,9 +476,10 @@ void solve_radiation(int argc, char** argv)
 
     Float tica_sza;
     Float tica_azi;
-    Array<ijk,1> center_path;
-    Array<Float,1> center_zh_tilt;
-    Array<Float,1> zh;
+
+    Array_gpu<ijk,1> center_path_gpu;
+    Array_gpu<int,1> center_path_bounds_gpu;
+    Array_gpu<Float,1> center_zh_tilt_gpu;
 
     mu0 = input_nc.get_variable<Float>("mu0", {n_col_y, n_col_x});
     azi = input_nc.get_variable<Float>("azi", {n_col_y, n_col_x});
@@ -496,8 +498,13 @@ void solve_radiation(int argc, char** argv)
     Array_gpu<Float,2> dei_gpu(dei);
     Array_gpu<Float,2> rh_gpu(rh);
 
+    Array_gpu<Float,1> grid_z_gpu(grid_z);
+    Array_gpu<Float,1> grid_zh_gpu(grid_zh);
+
     Gas_concs_gpu gas_concs_gpu(gas_concs);
     Aerosol_concs_gpu aerosol_concs_gpu(aerosol_concs);
+
+    Array_gpu<Float,1> p_lev_tilt_gpu;
 
     if (do_tilting)
     {
@@ -521,22 +528,23 @@ void solve_radiation(int argc, char** argv)
             "aermr08", "aermr09", "aermr10","aermr11"
         };
 
-        Array<Float,1> xh;
-        Array<Float,1> yh;
-        Array<Float,1> z;
+        Array<ijk,1> center_path;
+        Array<int,1> center_path_bounds({n_zh_in});
+        Array<Float,1> center_zh_tilt;
 
-        xh.set_dims({n_col_x+1});
-        xh = std::move(input_nc.get_variable<Float>("xh", {n_col_x+1}));
-        yh.set_dims({n_col_y+1});
-        yh = std::move(input_nc.get_variable<Float>("yh", {n_col_y+1}));
+        create_tilted_path(grid_xh.v(),grid_yh.v(),grid_zh.v(),grid_z.v(),tica_sza, tica_azi, 0.5, 0.5, center_path.v(), center_zh_tilt.v());
 
-        zh.set_dims({n_zh_in});
-        zh = std::move(input_nc.get_variable<Float>("zh", {n_zh_in}));
-        z.set_dims({n_z_in});
-        z = std::move(input_nc.get_variable<Float>("z", {n_z_in}));
+        int n_zh_tilt_center = center_zh_tilt.v().size();
+        center_path.set_dims({n_zh_tilt_center});
+        center_zh_tilt.set_dims({n_zh_tilt_center});
 
-        create_tilted_path(xh.v(),yh.v(),zh.v(),z.v(),tica_sza, tica_azi, 0.5, 0.5, center_path.v(), center_zh_tilt.v());
-        int n_z_tilt_center = center_zh_tilt.v().size() - 1;
+        get_tilted_path_bounds(n_zh_tilt_center, center_path.v(), center_path_bounds.v());
+
+        center_path_gpu = center_path;
+        center_path_bounds_gpu = center_path_bounds;
+        center_zh_tilt_gpu = center_zh_tilt;
+
+        p_lev_tilt_gpu.set_dims({n_zh_tilt_center});
 
         for (int icol=1; icol<=n_col; ++icol)
         {
@@ -548,9 +556,11 @@ void solve_radiation(int argc, char** argv)
                 tica_sza, tica_azi,
                 n_col_x, n_col_y, n_col,
                 n_lay, n_lev, n_z_in, n_zh_in,
-                xh, yh, zh, z,
+                grid_z_gpu, grid_zh_gpu,
                 p_lay_gpu, t_lay_gpu, p_lev_gpu, t_lev_gpu,
                 lwp_gpu, iwp_gpu, rel_gpu, dei_gpu, rh_gpu,
+                center_path_gpu, center_path_bounds_gpu,
+                center_zh_tilt_gpu, p_lev_tilt_gpu,
                 gas_concs_gpu, aerosol_concs_gpu,
                 gas_names, aerosol_names,
                 switch_cloud_optics, switch_liq_cloud_optics, switch_ice_cloud_optics, switch_aerosol_optics,
@@ -567,7 +577,7 @@ void solve_radiation(int argc, char** argv)
         cudaEventDestroy(stop);
 
         Status::print_message("Duration tilting: " + std::to_string(duration) + " (ms)");
-        Status::print_message("number of levels in tilted column: " + std::to_string(n_z_tilt_center));
+        Status::print_message("number of levels in tilted column: " + std::to_string(n_zh_tilt_center));
     }
 
 
@@ -1010,65 +1020,67 @@ void solve_radiation(int argc, char** argv)
         Array<Float,2> sw_aer_ssa_cpu(sw_aer_ssa);
         Array<Float,2> sw_aer_asy_cpu(sw_aer_asy);
 
-        Array<Float,2> sw_flux_up_cpu(sw_flux_up);
-        Array<Float,2> sw_flux_dn_cpu(sw_flux_dn);
-        Array<Float,2> sw_flux_dn_dir_cpu(sw_flux_dn_dir);
-        Array<Float,2> sw_flux_net_cpu(sw_flux_net);
+        Array<Float,2> sw_flux_up_cpu;
+        Array<Float,2> sw_flux_dn_cpu;
+        Array<Float,2> sw_flux_dn_dir_cpu;
+        Array<Float,2> sw_flux_net_cpu;
+
         Array<Float,2> sw_gpt_flux_up_cpu(sw_gpt_flux_up);
         Array<Float,2> sw_gpt_flux_dn_cpu(sw_gpt_flux_dn);
         Array<Float,2> sw_gpt_flux_dn_dir_cpu(sw_gpt_flux_dn_dir);
         Array<Float,2> sw_gpt_flux_net_cpu(sw_gpt_flux_net);
 
-        Array<Float,2> rt_flux_tod_up_cpu(rt_flux_tod_up);
         Array<Float,2> rt_flux_sfc_dir_cpu(rt_flux_sfc_dir);
         Array<Float,2> rt_flux_sfc_dif_cpu(rt_flux_sfc_dif);
         Array<Float,2> rt_flux_sfc_up_cpu(rt_flux_sfc_up);
-        Array<Float,3> rt_flux_abs_dir_cpu(rt_flux_abs_dir);
-        Array<Float,3> rt_flux_abs_dif_cpu(rt_flux_abs_dif);
+
+        Array<Float,2> rt_flux_tod_up_cpu;
+        Array<Float,3> rt_flux_abs_dir_cpu;
+        Array<Float,3> rt_flux_abs_dif_cpu;
 
         if (switch_tica)
         {
             // tilt back results or homogenize in case of high sza (> 85 degrees)
-            if (do_tilting)
-            {
-                // sw_flux_dn
-                translate_fluxes(n_col_x, n_col_y, n_lev, center_zh_tilt, zh, center_path.v(), sw_flux_dn_cpu);
+            Array_gpu<Float,2> sw_flux_dn_reversed;
+            Array_gpu<Float,2> sw_flux_dn_dir_reversed;
+            Array_gpu<Float,2> sw_flux_up_reversed;
+            Array_gpu<Float,2> sw_flux_net_reversed;
 
-                // sw_flux_dn_dir
-                translate_fluxes(n_col_x, n_col_y, n_lev, center_zh_tilt, zh, center_path.v(), sw_flux_dn_dir_cpu);
+            Array_gpu<Float,3> rt_flux_abs_dir_reversed;
+            Array_gpu<Float,3> rt_flux_abs_dif_reversed;
+            Array_gpu<Float,2> rt_flux_tod_up_reversed;
 
-                // sw_flux_up
-                translate_fluxes(n_col_x, n_col_y, n_lev, center_zh_tilt, zh, center_path.v(), sw_flux_up_cpu);
+            tica_reverse_gpu(
+                n_col_x, n_col_y, n_lay, n_lev, n_z, n_z_in, n_zh_in,
+                do_tilting, switch_twostream, switch_raytracing,
+                grid_zh_gpu, center_zh_tilt_gpu,
+                center_path_gpu, center_path_bounds_gpu,
+                p_lev_tilt_gpu,
+                sw_flux_dn, sw_flux_dn_dir, sw_flux_up, sw_flux_net,
+                rt_flux_abs_dir, rt_flux_abs_dif, rt_flux_tod_up,
+                sw_flux_dn_reversed, sw_flux_dn_dir_reversed, sw_flux_up_reversed, sw_flux_net_reversed,
+                rt_flux_abs_dir_reversed, rt_flux_abs_dif_reversed, rt_flux_tod_up_reversed);
 
-                // sw_flux_net
-                translate_fluxes(n_col_x, n_col_y, n_lev, center_zh_tilt, zh, center_path.v(), sw_flux_net_cpu);
+            sw_flux_dn_cpu = sw_flux_dn_reversed;
+            sw_flux_dn_dir_cpu = sw_flux_dn_dir_reversed;
+            sw_flux_up_cpu = sw_flux_up_reversed;
+            sw_flux_net_cpu = sw_flux_net_reversed;
 
-                // rt_flux_abs_dir
-                translate_heating(n_col_x, n_col_y, n_z, center_zh_tilt, zh, center_path.v(), rt_flux_abs_dir_cpu);
-
-                // rt_flux_abs_dif
-                translate_heating(n_col_x, n_col_y, n_z, center_zh_tilt, zh, center_path.v(), rt_flux_abs_dif_cpu);
-
-                // rt_flux_tod_up
-                translate_top(n_col_x, n_col_y, center_zh_tilt, center_path.v(), rt_flux_tod_up_cpu);
-
-            }
-            else
-            {
-                tica_mean(sw_flux_dn_cpu, n_col_x, n_col_y, n_lev);
-                tica_mean(sw_flux_dn_dir_cpu, n_col_x, n_col_y, n_lev);
-                tica_mean(sw_flux_up_cpu, n_col_x, n_col_y, n_lev);
-                tica_mean(sw_flux_net_cpu, n_col_x, n_col_y, n_lev);
-
-                tica_mean(rt_flux_abs_dir_cpu, n_col_x, n_col_y, n_z);
-                tica_mean(rt_flux_abs_dif_cpu, n_col_x, n_col_y, n_z);
-                tica_mean(rt_flux_tod_up_cpu, n_col_x, n_col_y, 1);
-                tica_mean(rt_flux_sfc_dir_cpu, n_col_x, n_col_y, 1);
-                tica_mean(rt_flux_sfc_dif_cpu, n_col_x, n_col_y, 1);
-                tica_mean(rt_flux_sfc_up_cpu, n_col_x, n_col_y, 1);
-            }
+            rt_flux_tod_up_cpu = rt_flux_tod_up_reversed;
+            rt_flux_abs_dir_cpu = rt_flux_abs_dir_reversed;
+            rt_flux_abs_dif_cpu = rt_flux_abs_dif_reversed;
         }
+        else
+        {
+            sw_flux_dn_cpu = sw_flux_dn;
+            sw_flux_dn_dir_cpu = sw_flux_dn_dir;
+            sw_flux_up_cpu = sw_flux_up;
+            sw_flux_net_cpu = sw_flux_net;
 
+            rt_flux_tod_up_cpu = rt_flux_tod_up;
+            rt_flux_abs_dir_cpu = rt_flux_abs_dir;
+            rt_flux_abs_dif_cpu = rt_flux_abs_dif;
+        }
         output_nc.add_dimension("gpt_sw", n_gpt_sw);
         output_nc.add_dimension("band_sw", n_bnd_sw);
 

--- a/src_test/test_rte_rrtmgp_rt.cu
+++ b/src_test/test_rte_rrtmgp_rt.cu
@@ -521,18 +521,6 @@ void solve_radiation(int argc, char** argv)
             "aermr08", "aermr09", "aermr10","aermr11"
         };
 
-        for (const auto& aerosol_name : aerosol_names) {
-            if (!aerosol_concs.exists(aerosol_name)) {
-                continue;
-            }
-            const Array<Float,2>& gas = aerosol_concs.get_vmr(aerosol_name);
-            if (gas.size() > 1) {
-                if (gas.get_dims()[0] == 1){
-                    aerosol_concs.set_vmr(aerosol_name, aerosol_concs.get_vmr(aerosol_name).subset({ {{1,n_col}, {1, n_lay}}} ));
-                }
-            }
-        }
-
         Array<Float,1> xh;
         Array<Float,1> yh;
         Array<Float,1> z;

--- a/src_test/test_rte_rrtmgp_rt.cu
+++ b/src_test/test_rte_rrtmgp_rt.cu
@@ -484,10 +484,6 @@ void solve_radiation(int argc, char** argv)
     mu0 = input_nc.get_variable<Float>("mu0", {n_col_y, n_col_x});
     azi = input_nc.get_variable<Float>("azi", {n_col_y, n_col_x});
 
-    bool do_tilting = false;
-    if (switch_tica && mu0.v()[0] > 0.087)     // mu0 = 0.087 roughly corresponds to a sza of 85 degrees
-        do_tilting = true;
-
     Array_gpu<Float,2> p_lay_gpu(p_lay);
     Array_gpu<Float,2> p_lev_gpu(p_lev);
     Array_gpu<Float,2> t_lay_gpu(t_lay);
@@ -506,7 +502,7 @@ void solve_radiation(int argc, char** argv)
 
     Array_gpu<Float,1> p_lev_tilt_gpu;
 
-    if (do_tilting)
+    if (switch_tica)
     {
         cudaDeviceSynchronize();
         cudaEvent_t start;
@@ -843,7 +839,7 @@ void solve_radiation(int argc, char** argv)
         }
 
         Array<Float,1> tica_scaling({n_col});
-        if (do_tilting)
+        if (switch_tica)
         {
             for (int icol=1; icol<=n_col; ++icol)
             {
@@ -955,7 +951,7 @@ void solve_radiation(int argc, char** argv)
                     switch_single_gpt,
                     switch_delta_cloud,
                     switch_delta_aerosol,
-                    do_tilting,
+                    switch_tica,
                     single_gpt,
                     photons_per_pixel,
                     grid_cells,
@@ -1052,7 +1048,7 @@ void solve_radiation(int argc, char** argv)
 
             tica_reverse_gpu(
                 n_col_x, n_col_y, n_lay, n_lev, n_z, n_z_in, n_zh_in,
-                do_tilting, switch_twostream, switch_raytracing,
+                switch_twostream, switch_raytracing,
                 grid_zh_gpu, center_zh_tilt_gpu,
                 center_path_gpu, center_path_bounds_gpu,
                 p_lev_tilt_gpu,

--- a/src_test/test_rte_rrtmgp_rt.cu
+++ b/src_test/test_rte_rrtmgp_rt.cu
@@ -521,7 +521,7 @@ void solve_radiation(int argc, char** argv)
         z.set_dims({n_z_in});
         z = std::move(input_nc.get_variable<Float>("z", {n_z_in}));
 
-        tilted_path(xh.v(),yh.v(),zh.v(),z.v(),tica_sza, tica_azi, 0.5, 0.5, center_path.v(), center_zh_tilt.v());
+        create_tilted_path(xh.v(),yh.v(),zh.v(),z.v(),tica_sza, tica_azi, 0.5, 0.5, center_path.v(), center_zh_tilt.v());
         int n_z_tilt_center = center_zh_tilt.v().size() - 1;
 
         for (int icol=1; icol<=n_col; ++icol)

--- a/src_tilt/CMakeLists.txt
+++ b/src_tilt/CMakeLists.txt
@@ -5,6 +5,6 @@ FILE(GLOB sourcefiles
         "../src_tilt/tilt_utils.*"
 )
 
-include_directories("../include" "../include_rt" "../include_tilt" "../include_test" SYSTEM ${INCLUDE_DIRS})
+include_directories("../include" "../include_rt_kernels" "../include_rt" "../include_tilt" "../include_test" SYSTEM ${INCLUDE_DIRS})
 
 add_library(rte_rrtmgp_tilt STATIC ${sourcefiles})

--- a/src_tilt/CMakeLists.txt
+++ b/src_tilt/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This file is part of a C++ interface to the Radiative Transfer for Energetics (RTE)
 #
 FILE(GLOB sourcefiles
-        "../src_tilt/tilt_utils.cpp"
+        "../src_tilt/tilt_utils.*"
 )
 
 include_directories("../include" "../include_rt" "../include_tilt" "../include_test" SYSTEM ${INCLUDE_DIRS})

--- a/src_tilt/tilt_utils.cpp
+++ b/src_tilt/tilt_utils.cpp
@@ -14,12 +14,10 @@
 #include "Aerosol_optics_rt.h"
 #include "tilt_utils.h"
 #include "types.h"
-
-
-void tilted_path(std::vector<Float>& xh, std::vector<Float>& yh,
-                 std::vector<Float>& zh, std::vector<Float>& z,
-                 Float sza, Float azi,
-                 Float x_start, Float y_start,
+void create_tilted_path(const std::vector<Float>& xh, const std::vector<Float>& yh,
+                 const std::vector<Float>& zh, const std::vector<Float>& z,
+                 const Float sza, const Float azi,
+                 const Float x_start, const Float y_start,
                  std::vector<ijk>& tilted_path,
                  std::vector<Float>& zh_tilted)
 {
@@ -138,18 +136,6 @@ void tilted_path(std::vector<Float>& xh, std::vector<Float>& yh,
         // Record the path segment
         dz_tilted[z_idx] += dz0;
 
-        // Record boundary crossing
-        // if path is larger than 1 cm
-        if (l > min_step)
-        {
-            if ((std::abs(l - lx) < epsilon) || (std::abs(l - ly) < epsilon) ||
-                ((std::abs(l - lz) < epsilon || zp >= zh[k + 1]))) {
-                // Create a new path segment after crossing boundary
-                tilted_path.push_back({i, j, k});
-                dz_tilted.push_back(0.0);
-                z_idx += 1;
-            }
-        }
 
         // Check z boundary crossing
         if ((std::abs(l - lz) < epsilon || zp >= zh[k+1])) {
@@ -170,6 +156,20 @@ void tilted_path(std::vector<Float>& xh, std::vector<Float>& yh,
             i = int(i + sign(dx0));
             i = (i == -1) ? n_x - 1 : i%n_x;
             xp = dx0 < 0 ? xh[i+1] : xh[i];
+        }
+
+        // Record boundary crossing
+        // if path is larger than 1 cm
+        if (l > min_step)
+        {
+            if ((std::abs(l - lx) < epsilon) || (std::abs(l - ly) < epsilon) ||
+                ((std::abs(l - lz) < epsilon || zp >= zh[k + 1]))) {
+                // Create a new path segment after crossing boundary
+                tilted_path.push_back({i, j, k});
+                dz_tilted.push_back(0.0);
+                z_idx += 1;
+
+            }
         }
     }
     // Construct final zh_tilted
@@ -408,7 +408,7 @@ void compress_columns_weighted_avg(const int n_x, const int n_y,
     var = var_tmp;
 }
 
-void compress_columns_p_or_t(const int n_x, const int n_y, 
+void compress_columns_p_or_t(const int n_x, const int n_y,
                       const int n_out_lay,  const int n_tilt,
                       const Array<ijk,1>& path,
                       const Array<Float,1>& zh_tilt, const Array<Float,1>& zh,
@@ -450,9 +450,10 @@ void compress_columns_p_or_t(const int n_x, const int n_y,
             for (int ix = 0; ix < n_x; ++ix)
             {
                 const int out_idx = ix + iy * n_x + ilay * n_x * n_y;
+                const int out_idx_top = ix + iy * n_x + (ilay+1) * n_x * n_y;
                 const float dz =  zh.v()[ilay+1] - zh.v()[ilay];
                 var_tmp_lay[out_idx] = (var_tmp_lev[out_idx] * (z.v()[ilay] - zh.v()[ilay]) / dz
-                                        + var_tmp_lev[out_idx + 1] * (zh.v()[ilay + 1] - z.v()[ilay]) / dz);
+                                        + var_tmp_lev[out_idx_top] * (zh.v()[ilay + 1] - z.v()[ilay]) / dz);
             }
         }
     }
@@ -464,8 +465,8 @@ void tilt_and_compress_fields(const int n_z_in, const int n_zh_in, const int n_c
     const int n_z_tilt, const int n_zh_tilt, const int n_col,
     const Array<Float,1>& zh, const Array<Float,1>& z,
     const Array<Float,1>& zh_tilt, const Array<ijk,1>& path,
-    Array<Float,2>* p_lay_copy, Array<Float,2>* t_lay_copy, Array<Float,2>* p_lev_copy, Array<Float,2>* t_lev_copy, 
-    Array<Float,2>* rh_copy, 
+    Array<Float,2>* p_lay_copy, Array<Float,2>* t_lay_copy, Array<Float,2>* p_lev_copy, Array<Float,2>* t_lev_copy,
+    Array<Float,2>* rh_copy,
     Gas_concs& gas_concs_copy, const std::vector<std::string>& gas_names,
     Aerosol_concs& aerosol_concs_copy, const std::vector<std::string>& aerosol_names, const bool switch_aerosol_optics)
 {
@@ -482,6 +483,7 @@ void tilt_and_compress_fields(const int n_z_in, const int n_zh_in, const int n_c
     t_lev_copy->expand_dims({n_col, n_zh_in});
 
     create_tilted_columns_levlay(n_col_x, n_col_y, n_z_in, n_zh_in, zh.v(), z.v(), zh_tilt.v(), path.v(), p_lay_copy->v(), p_lev_copy->v());
+
     p_lay_copy->expand_dims({n_col, n_z_tilt});
     p_lev_copy->expand_dims({n_col, n_zh_tilt});
     // do not compress P here, as pressure at tilted levels is required for weighting of gasses and aerosol
@@ -526,7 +528,7 @@ void tilt_and_compress_fields(const int n_z_in, const int n_zh_in, const int n_c
             else {
                 throw std::runtime_error("No tilted column implementation for single column profiles.");
             }
-        } 
+        }
     }
 
     // aerosols
@@ -564,7 +566,7 @@ void tilt_and_compress_fields(const int n_z_in, const int n_zh_in, const int n_c
                 else {
                     throw std::runtime_error("No tilted column implementation for single column profiles.");
                 }
-            } 
+            }
         }
     }
 
@@ -749,11 +751,10 @@ void tica_tilt(
     ////// SETUP FOR CENTER START POINT TILTING //////
     Array<ijk,1> center_path;
     Array<Float,1> center_zh_tilt;
-    tilted_path(xh.v(),yh.v(),zh.v(),z.v(),sza,azi, 0.5, 0.5, center_path.v(), center_zh_tilt.v());
+    create_tilted_path(xh.v(),yh.v(),zh.v(),z.v(),sza,azi, 0.5, 0.5, center_path.v(), center_zh_tilt.v());
 
     int n_zh_tilt_center = center_zh_tilt.v().size();
     int n_z_tilt_center = n_zh_tilt_center - 1;
-
     center_path.set_dims({n_z_tilt_center});
     center_zh_tilt.set_dims({n_zh_tilt_center});
 
@@ -794,7 +795,7 @@ void tica_tilt(
             Array<ijk,1> path;
             Array<Float,1> zh_tilt;
 
-            tilted_path(xh.v(), yh.v(), zh.v(), z.v(), sza, azi, x_start, y_start, path.v(), zh_tilt.v());
+            create_tilted_path(xh.v(), yh.v(), zh.v(), z.v(), sza, azi, x_start, y_start, path.v(), zh_tilt.v());
             int n_zh_tilt = zh_tilt.v().size();
             int n_z_tilt = n_zh_tilt - 1;
 

--- a/src_tilt/tilt_utils.cpp
+++ b/src_tilt/tilt_utils.cpp
@@ -763,19 +763,6 @@ void tica_tilt(
         int rnd_seed
 )
 {
-    // if t lev all 0, interpolate from t lay
-    if (*std::max_element(t_lev_out.v().begin(), t_lev_out.v().end()) <= 0) {
-        for (int i = 1; i <= n_col; ++i) {
-            for (int j = 2; j <= n_lay; ++j) {
-                t_lev_out({i, j}) = (t_lay_out({i, j}) + t_lay_out({i, j - 1})) / 2.0;
-            }
-            t_lev_out({i, n_lev}) = 2 * t_lay_out({i, n_lay}) - t_lev_out({i,n_lay});
-            t_lev_out({i, 1}) = 2 * t_lay_out({i, 1}) - t_lev_out({i,2});
-        }
-    }
-    // copy interpolated values into t_lev too
-    t_lev = t_lev_out;
-
     ////// SETUP FOR CENTER START POINT TILTING //////
     Array<ijk,1> center_path;
     Array<Float,1> center_zh_tilt;

--- a/src_tilt/tilt_utils.cpp
+++ b/src_tilt/tilt_utils.cpp
@@ -186,7 +186,7 @@ void create_tilted_path(const std::vector<Float>& xh, const std::vector<Float>& 
     }
 }
 
-void get_tilted_path_bounds(const int n_z_tilt,
+void get_tilted_path_bounds(const int n_zh_tilt,
                 const std::vector<ijk>& tilted_path,
                 std::vector<int>& tilted_path_bounds)
 {
@@ -195,7 +195,7 @@ void get_tilted_path_bounds(const int n_z_tilt,
 
     tilted_path_bounds[ilay] = k;
 
-    for (int i=1; i < n_z_tilt; ++i)
+    for (int i=1; i < n_zh_tilt; ++i)
     {
         if (tilted_path[i].k > k)
         {
@@ -787,7 +787,7 @@ void tica_tilt(
     center_zh_tilt.set_dims({n_zh_tilt_center});
 
     Array<int,1> center_path_bounds({n_zh_in});
-    get_tilted_path_bounds(n_z_tilt_center, center_path.v(), center_path_bounds.v());
+    get_tilted_path_bounds(n_zh_tilt_center, center_path.v(), center_path_bounds.v());
 
     tilt_and_compress_fields(n_z_in, n_zh_in, n_col_x, n_col_y,
                 n_z_tilt_center, n_zh_tilt_center, n_col,

--- a/src_tilt/tilt_utils.cpp
+++ b/src_tilt/tilt_utils.cpp
@@ -1436,7 +1436,8 @@ void tica_tilt_simple(
         }
         const Array<Float,2>& gas = gas_concs_out.get_vmr(gas_name);
         if (gas.size() > 1) {
-            if (gas.get_dims()[0] > 1) { // checking: do we have 3D field?
+            if (gas.get_dims()[0] > 1)
+            { // checking: do we have 3D field?
                 Array<Float,2> gas_tmp(gas);
                 create_tilted_columns_simple(n_col_x, n_col_y, center_path.v(), gas_tmp.v());
                 gas_tmp.expand_dims({n_col, n_z_tilt_center});

--- a/src_tilt/tilt_utils.cpp
+++ b/src_tilt/tilt_utils.cpp
@@ -48,10 +48,11 @@ void create_tilted_path(const std::vector<Float>& xh, const std::vector<Float>& 
     const Float epsilon = 1e-8; // Small value to handle floating-point precision
     const Float min_step = 1e-2; // Minimum step size in meters
 
-    tilted_path.push_back({i, j, k}); // Add starting point
-    dz_tilted.push_back(0.0);
+    //tilted_path.push_back({i, j, k}); // Add starting point
+    //dz_tilted.push_back(0.0);
     z_idx = 0;
 
+    Float dz = 0;
     while (zp < z_top)
     {
         // Check bounds before accessing arrays
@@ -134,7 +135,22 @@ void create_tilted_path(const std::vector<Float>& xh, const std::vector<Float>& 
         zp += dz0;
 
         // Record the path segment
-        dz_tilted[z_idx] += dz0;
+        dz += dz0;
+
+        // Record boundary crossing
+        // if path is larger than 1 cm
+        if (l > min_step)
+        {
+            if ((std::abs(l - lx) < epsilon) || (std::abs(l - ly) < epsilon) ||
+                ((std::abs(l - lz) < epsilon || zp >= zh[k + 1]))) {
+                // Create a new path segment after crossing boundary
+                tilted_path.push_back({i, j, k});
+                dz_tilted.push_back(dz);
+                dz = 0;
+                z_idx += 1;
+
+            }
+        }
 
 
         // Check z boundary crossing
@@ -158,20 +174,10 @@ void create_tilted_path(const std::vector<Float>& xh, const std::vector<Float>& 
             xp = dx0 < 0 ? xh[i+1] : xh[i];
         }
 
-        // Record boundary crossing
-        // if path is larger than 1 cm
-        if (l > min_step)
-        {
-            if ((std::abs(l - lx) < epsilon) || (std::abs(l - ly) < epsilon) ||
-                ((std::abs(l - lz) < epsilon || zp >= zh[k + 1]))) {
-                // Create a new path segment after crossing boundary
-                tilted_path.push_back({i, j, k});
-                dz_tilted.push_back(0.0);
-                z_idx += 1;
-
-            }
-        }
     }
+
+    tilted_path.push_back({i, j, k});
+
     // Construct final zh_tilted
     zh_tilted.clear();
     zh_tilted.push_back(0.);
@@ -179,6 +185,28 @@ void create_tilted_path(const std::vector<Float>& xh, const std::vector<Float>& 
         zh_tilted.push_back(zh_tilted[iz] + dz_tilted[iz]);
     }
 }
+
+void get_tilted_path_bounds(const int n_z_tilt,
+                const std::vector<ijk>& tilted_path,
+                std::vector<int>& tilted_path_bounds)
+{
+    int k = 0;
+    int ilay = 0;
+
+    tilted_path_bounds[ilay] = k;
+
+    for (int i=1; i < n_z_tilt; ++i)
+    {
+        if (tilted_path[i].k > k)
+        {
+            ++ilay;
+            tilted_path_bounds[ilay] = i;
+            k = tilted_path[i].k;
+        }
+    }
+}
+
+
 
 void restore_bkg_profile(const int n_x, const int n_y,
                       const int n_full,
@@ -584,8 +612,8 @@ void create_tilted_columns(const int n_x, const int n_y, const int n_lay_in, con
                            const std::vector<Float>& zh_tilted, const std::vector<ijk>& tilted_path,
                            std::vector<Float>& var)
 {
-    const int n_lay = tilted_path.size();
     const int n_lev = zh_tilted.size();
+    const int n_lay = n_lev-1;
 
     std::vector<Float> var_tmp(n_lay*n_x*n_y);
 
@@ -690,8 +718,8 @@ void create_tilted_columns_levlay(const int n_x, const int n_y, const int n_lay_
                                  std::vector<Float>& var_lay, std::vector<Float>& var_lev)
 
 {
-    const int n_lay = tilted_path.size();
     const int n_lev = zh_tilted.size();
+    const int n_lay = n_lev - 1;
     std::vector<Float> z_tilted(n_lay);
     for (int ilay=0; ilay<n_lay; ++ilay)
         z_tilted[ilay] = (zh_tilted[ilay]+zh_tilted[ilay+1])/Float(2.);
@@ -755,8 +783,11 @@ void tica_tilt(
 
     int n_zh_tilt_center = center_zh_tilt.v().size();
     int n_z_tilt_center = n_zh_tilt_center - 1;
-    center_path.set_dims({n_z_tilt_center});
+    center_path.set_dims({n_zh_tilt_center});
     center_zh_tilt.set_dims({n_zh_tilt_center});
+
+    Array<int,1> center_path_bounds({n_zh_in});
+    get_tilted_path_bounds(n_z_tilt_center, center_path.v(), center_path_bounds.v());
 
     tilt_and_compress_fields(n_z_in, n_zh_in, n_col_x, n_col_y,
                 n_z_tilt_center, n_zh_tilt_center, n_col,
@@ -1147,7 +1178,8 @@ void tica_mean(Array<Float,3>& var, const int n_x, const int n_y, const int n_z_
 void create_tilted_columns_simple(const int n_x, const int n_y, const std::vector<ijk>& tilted_path,
                            std::vector<Float>& var)
 {
-    const int n_lay = tilted_path.size();
+    const int n_lev = tilted_path.size();
+    const int n_lay = n_lev - 1;
 
     std::vector<Float> var_tmp(n_lay*n_x*n_y);
 
@@ -1218,7 +1250,8 @@ void create_tilted_columns_clouds_simple(const int n_x, const int n_y, const std
                                   std::vector<Float>& water_path, std::vector<Float>& effective_size,
                                   const std::vector<Float>& zh)
 {
-    const int n_lay = tilted_path.size();
+    const int n_lev = tilted_path.size();
+    const int n_lay = n_lev-1;
 
     std::vector<Float> water_path_tmp(n_lay*n_x*n_y);
     std::vector<Float> effective_size_tmp(n_lay*n_x*n_y);

--- a/src_tilt/tilt_utils.cu
+++ b/src_tilt/tilt_utils.cu
@@ -647,7 +647,7 @@ void tica_tilt_gpu(
 void tica_reverse_gpu(
         const int n_col_x, const int n_col_y, const int n_lay, const int n_lev,
         const int n_z, const int n_z_in, const int n_zh_in ,
-        const bool do_tilting, const bool switch_twostream, const bool switch_raytracing,
+        const bool switch_twostream, const bool switch_raytracing,
         const Array_gpu<Float,1>& zh, const Array_gpu<Float,1>& zh_tilt,
         const Array_gpu<ijk,1>& tilted_path, const Array_gpu<int,1>& tilted_path_bounds,
         const Array_gpu<Float,1>& p_lev_tilt,
@@ -679,146 +679,63 @@ void tica_reverse_gpu(
     dim3 grid_2d(grid_col_x, grid_col_y, 1);
     dim3 block_2d(block_col_x, block_col_y, 1);
 
-    if (do_tilting)
+
+    if (switch_twostream)
     {
-        if (switch_twostream)
-        {
-            sw_flux_dn.set_dims({n_col, n_lev});
-            sw_flux_dn_dir.set_dims({n_col, n_lev});
-            sw_flux_up.set_dims({n_col, n_lev});
-            sw_flux_net.set_dims({n_col, n_lev});
+        sw_flux_dn.set_dims({n_col, n_lev});
+        sw_flux_dn_dir.set_dims({n_col, n_lev});
+        sw_flux_up.set_dims({n_col, n_lev});
+        sw_flux_net.set_dims({n_col, n_lev});
 
-            translate_twostream_fluxes_gpu<<<grid_3d_lev, block_3d_lev>>>(
-                    n_col_x, n_col_y, n_z_in, n_lev,
-                    tilted_path.ptr(), tilted_path_bounds.ptr(),
-                    sw_flux_dn_tilt.ptr(), sw_flux_dn.ptr());
-            translate_twostream_fluxes_gpu<<<grid_3d_lev, block_3d_lev>>>(
-                    n_col_x, n_col_y, n_z_in, n_lev,
-                    tilted_path.ptr(), tilted_path_bounds.ptr(),
-                    sw_flux_dn_dir_tilt.ptr(), sw_flux_dn_dir.ptr());
-            translate_twostream_fluxes_gpu<<<grid_3d_lev, block_3d_lev>>>(
-                    n_col_x, n_col_y, n_z_in, n_lev,
-                    tilted_path.ptr(), tilted_path_bounds.ptr(),
-                    sw_flux_up_tilt.ptr(), sw_flux_up.ptr());
-            translate_twostream_fluxes_gpu<<<grid_3d_lev, block_3d_lev>>>(
-                    n_col_x, n_col_y, n_z_in, n_lev,
-                    tilted_path.ptr(), tilted_path_bounds.ptr(),
-                    sw_flux_net_tilt.ptr(), sw_flux_net.ptr());
-        }
-
-        if (switch_raytracing)
-        {
-            rt_flux_abs_dir.set_dims({n_col_x, n_col_y, n_z});
-            rt_flux_abs_dif.set_dims({n_col_x, n_col_y, n_z});
-            rt_flux_tod_up.set_dims({n_col_x, n_col_y});
-
-            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_col_x, n_col_y, n_z, rt_flux_abs_dir.ptr());
-            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_col_x, n_col_y, n_z, rt_flux_abs_dif.ptr());
-
-            translate_absorption_gpu<<<grid_3d_z, block_3d_z>>>(
-                    n_col_x, n_col_y, n_z_in, n_z,
-                    tilted_path.ptr(),
-                    tilted_path_bounds.ptr(),
-                    p_lev_tilt.ptr(),
-                    rt_flux_abs_dir_tilt.ptr(),
-                    rt_flux_abs_dir.ptr());
-
-            translate_absorption_gpu<<<grid_3d_z, block_3d_z>>>(
-                    n_col_x, n_col_y, n_z_in, n_z,
-                    tilted_path.ptr(),
-                    tilted_path_bounds.ptr(),
-                    p_lev_tilt.ptr(),
-                    rt_flux_abs_dif_tilt.ptr(),
-                    rt_flux_abs_dif.ptr());
-
-            translate_toa_flux_gpu<<<grid_2d, block_2d>>>(
-                    n_col_x, n_col_y, n_zh_tilted,
-                    tilted_path.ptr(),
-                    tilted_path_bounds.ptr(),
-                    rt_flux_tod_up_tilt.ptr(),
-                    rt_flux_tod_up.ptr());
-        }
+        translate_twostream_fluxes_gpu<<<grid_3d_lev, block_3d_lev>>>(
+                n_col_x, n_col_y, n_z_in, n_lev,
+                tilted_path.ptr(), tilted_path_bounds.ptr(),
+                sw_flux_dn_tilt.ptr(), sw_flux_dn.ptr());
+        translate_twostream_fluxes_gpu<<<grid_3d_lev, block_3d_lev>>>(
+                n_col_x, n_col_y, n_z_in, n_lev,
+                tilted_path.ptr(), tilted_path_bounds.ptr(),
+                sw_flux_dn_dir_tilt.ptr(), sw_flux_dn_dir.ptr());
+        translate_twostream_fluxes_gpu<<<grid_3d_lev, block_3d_lev>>>(
+                n_col_x, n_col_y, n_z_in, n_lev,
+                tilted_path.ptr(), tilted_path_bounds.ptr(),
+                sw_flux_up_tilt.ptr(), sw_flux_up.ptr());
+        translate_twostream_fluxes_gpu<<<grid_3d_lev, block_3d_lev>>>(
+                n_col_x, n_col_y, n_z_in, n_lev,
+                tilted_path.ptr(), tilted_path_bounds.ptr(),
+                sw_flux_net_tilt.ptr(), sw_flux_net.ptr());
     }
-    else
+
+    if (switch_raytracing)
     {
-        Array_gpu<Float,1> mean_profile({n_lev});
-        const Float n_col_inv = Float(1.) / (n_col_x * n_col_y);
+        rt_flux_abs_dir.set_dims({n_col_x, n_col_y, n_z});
+        rt_flux_abs_dif.set_dims({n_col_x, n_col_y, n_z});
+        rt_flux_tod_up.set_dims({n_col_x, n_col_y});
 
-        if (switch_twostream)
-        {
-            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_lev, mean_profile.ptr());
+        Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_col_x, n_col_y, n_z, rt_flux_abs_dir.ptr());
+        Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_col_x, n_col_y, n_z, rt_flux_abs_dif.ptr());
 
-            tica_mean_profile<<<grid_3d_lev, block_3d_lev>>>(
-                    n_col_x, n_col_y, n_lev, n_col_inv,
-                    sw_flux_dn_tilt.ptr(), mean_profile.ptr());
+        translate_absorption_gpu<<<grid_3d_z, block_3d_z>>>(
+                n_col_x, n_col_y, n_z_in, n_z,
+                tilted_path.ptr(),
+                tilted_path_bounds.ptr(),
+                p_lev_tilt.ptr(),
+                rt_flux_abs_dir_tilt.ptr(),
+                rt_flux_abs_dir.ptr());
 
-            tica_profile_to_3d<<<grid_3d_lev, block_3d_lev>>>(
-                    n_col_x, n_col_y, n_lev, n_col_inv,
-                    mean_profile.ptr(), sw_flux_dn.ptr());
+        translate_absorption_gpu<<<grid_3d_z, block_3d_z>>>(
+                n_col_x, n_col_y, n_z_in, n_z,
+                tilted_path.ptr(),
+                tilted_path_bounds.ptr(),
+                p_lev_tilt.ptr(),
+                rt_flux_abs_dif_tilt.ptr(),
+                rt_flux_abs_dif.ptr());
 
-            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_lev, mean_profile.ptr());
-
-            tica_mean_profile<<<grid_3d_lev, block_3d_lev>>>(
-                    n_col_x, n_col_y, n_lev, n_col_inv,
-                    sw_flux_dn_dir_tilt.ptr(), mean_profile.ptr());
-
-            tica_profile_to_3d<<<grid_3d_lev, block_3d_lev>>>(
-                    n_col_x, n_col_y, n_lev, n_col_inv,
-                    mean_profile.ptr(), sw_flux_dn_dir.ptr());
-
-            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_lev, mean_profile.ptr());
-
-            tica_mean_profile<<<grid_3d_lev, block_3d_lev>>>(
-                    n_col_x, n_col_y, n_lev, n_col_inv,
-                    sw_flux_up_tilt.ptr(), mean_profile.ptr());
-
-            tica_profile_to_3d<<<grid_3d_lev, block_3d_lev>>>(
-                    n_col_x, n_col_y, n_lev, n_col_inv,
-                    mean_profile.ptr(), sw_flux_up.ptr());
-
-            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_lev, mean_profile.ptr());
-
-            tica_mean_profile<<<grid_3d_lev, block_3d_lev>>>(
-                    n_col_x, n_col_y, n_lev, n_col_inv,
-                    sw_flux_net.ptr(), mean_profile.ptr());
-
-            tica_profile_to_3d<<<grid_3d_lev, block_3d_lev>>>(
-                    n_col_x, n_col_y, n_lev, n_col_inv,
-                    mean_profile.ptr(), sw_flux_net.ptr());
-        }
-        if (switch_raytracing)
-        {
-            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_lev, mean_profile.ptr());
-
-            tica_mean_profile<<<grid_3d_z, block_3d_z>>>(
-                    n_col_x, n_col_y, n_z, n_col_inv,
-                    rt_flux_abs_dir.ptr(), mean_profile.ptr());
-
-            tica_profile_to_3d<<<grid_3d_z, block_3d_z>>>(
-                    n_col_x, n_col_y, n_z, n_col_inv,
-                    mean_profile.ptr(), rt_flux_abs_dir.ptr());
-
-            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_lev, mean_profile.ptr());
-
-            tica_mean_profile<<<grid_3d_z, block_3d_z>>>(
-                    n_col_x, n_col_y, n_z, n_col_inv,
-                    rt_flux_abs_dif.ptr(), mean_profile.ptr());
-
-            tica_profile_to_3d<<<grid_3d_z, block_3d_z>>>(
-                    n_col_x, n_col_y, n_z, n_col_inv,
-                    mean_profile.ptr(), rt_flux_abs_dif.ptr());
-
-
-            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_lev, mean_profile.ptr());
-
-            tica_mean_profile<<<grid_2d, block_2d>>>(
-                    n_col_x, n_col_y, 1, n_col_inv,
-                    rt_flux_tod_up.ptr(), mean_profile.ptr());
-
-            tica_profile_to_3d<<<grid_2d, block_2d>>>(
-                    n_col_x, n_col_y, 1, n_col_inv,
-                    mean_profile.ptr(), rt_flux_tod_up.ptr());
-        }
+        translate_toa_flux_gpu<<<grid_2d, block_2d>>>(
+                n_col_x, n_col_y, n_zh_tilted,
+                tilted_path.ptr(),
+                tilted_path_bounds.ptr(),
+                rt_flux_tod_up_tilt.ptr(),
+                rt_flux_tod_up.ptr());
     }
 }
 

--- a/src_tilt/tilt_utils.cu
+++ b/src_tilt/tilt_utils.cu
@@ -437,7 +437,8 @@ void tica_tilt_gpu(
             if (aerosol.size() > 1)
             {
                 if (aerosol.get_dims()[0] > 1)
-                { // checking: do we have 3D field?
+                {
+                    //  Only tilt if we have a 3D aerosol field
                     tilt_layers_gpu<<<grid_3d_2, block_3d_2>>>(
                             n_col_x, n_col_y, n_z_tilt_center,
                             center_path_gpu.ptr(),
@@ -450,10 +451,6 @@ void tica_tilt_gpu(
                             aerosol.ptr());
 
                     aerosol_concs.set_vmr(aerosol_name, aerosol);
-                }
-                else
-                {
-                    throw std::runtime_error("No tilted column implementation for single column profiles.");
                 }
             }
         }

--- a/src_tilt/tilt_utils.cu
+++ b/src_tilt/tilt_utils.cu
@@ -1,0 +1,565 @@
+#include <cmath>
+#include <chrono>
+#include <boost/algorithm/string.hpp>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <vector>
+
+#include "Status.h"
+#include "Netcdf_interface.h"
+#include "Array.h"
+#include "Gas_concs.h"
+#include "Aerosol_optics_rt.h"
+#include "tilt_utils.h"
+#include "types.h"
+
+
+namespace
+{
+    __device__
+    Float interpolate_gpu(const int n_x, const int n_y, const int n_lay_in,
+                          const Float* zf_in, const Float* zh_in,
+                          const Float* vlay_in, const Float* vlev_in,
+                          const int ix, const int iy,
+                          const Float zp, const ijk offset)
+    {
+
+            const int n_col = n_x * n_y;
+            const int n_lev_in = n_lay_in + 1;
+
+            int posh_bot = 0;
+            int posf_bot = 0;
+            for (int ilev=0; ilev<n_lev_in-1; ++ilev)
+                if (zh_in[ilev] < zp)
+                    posh_bot = ilev;
+            for (int ilay=0; ilay<n_lay_in; ++ilay)
+                if (zf_in[ilay] < zp)
+                    posf_bot = ilay;
+            const Float* v_top;
+            const Float* v_bot;
+            Float  z_top;
+            Float  z_bot;
+
+            const int zh_top = zh_in[posh_bot+1];
+            const int zh_bot = zh_in[posh_bot];
+            const int zf_top = (posf_bot+1 < n_lay_in) ? zf_in[posf_bot+1] : zh_top+1;
+            const int zf_bot = zf_in[posf_bot];
+
+            // tilted layers between the lowest level and layer
+            if (posf_bot == 0 && posh_bot == 0 && zp < zf_in[0])
+            {
+                v_top = &vlay_in[posf_bot*n_col];
+                z_top = zf_in[posf_bot];
+                v_bot = &vlev_in[posh_bot*n_col];
+                z_bot = zh_in[posh_bot];
+            }
+            // tilted layers between the top layer and level
+            else if (posf_bot == n_lay_in - 1 && posh_bot == n_lev_in -2)
+            {
+                v_top = &vlev_in[(posh_bot + 1) * n_col];
+                z_top = zh_in[posh_bot + 1];
+                v_bot = &vlay_in[posf_bot * n_col];
+                z_bot = zf_in[posf_bot];
+            }
+            // all layers in between
+            else
+            {
+                if (zh_top > zf_top)
+                {
+                    v_top = &vlay_in[(posf_bot + 1) * n_col];
+                    z_top = zf_in[posf_bot + 1];
+                }
+                else
+                {
+                    v_top = &vlev_in[(posh_bot + 1) * n_col];
+                    z_top = zh_in[posh_bot + 1];
+                }
+                if (zh_bot < zf_bot)
+                {
+                    v_bot = &vlay_in[posf_bot * n_col];
+                    z_bot = zf_in[posf_bot];
+                }
+                else
+                {
+                    v_bot = &vlev_in[posh_bot * n_col];
+                    z_bot = zh_in[posh_bot];
+                }
+            }
+
+            Float dz = z_top-z_bot;
+
+            const int idx = (ix + offset.i)%n_x + (iy+offset.j)%n_y * n_x;
+            const Float value = (zp-z_bot)/dz*v_top[idx] + (z_top-zp)/dz*v_bot[idx];
+            return value;
+    }
+
+
+
+    __global__
+    void tilt_plev_gpu(const int n_x, const int n_y, const int n_z, const int n_z_tilt,
+                       const ijk* tilted_path,
+                       const Float* zh_tilt,
+                       const Float* z, const Float* zh,
+                       const Float* p_lay, const Float* p_lev,
+                       Float* p_lev_tilt)
+    {
+        const int i = blockIdx.x*blockDim.x + threadIdx.x;
+
+        if ( (i < (n_z_tilt+1) ) )
+        {
+            const Float pos_z = zh_tilt[i];
+            const Float p = interpolate_gpu(n_x, n_y, n_z, z, zh, p_lay, p_lev, 0, 0, pos_z, tilted_path[i]);
+            p_lev_tilt[i] = p;
+        }
+    }
+
+    __global__
+    void tilt_tlay_gpu(const int n_x, const int n_y, const int n_z, const int n_z_tilt,
+                       const ijk* tilted_path,
+                       const Float* z_tilt,
+                       const Float* z, const Float* zh,
+                       const Float* p_lay, const Float* p_lev,
+                       Float* t_lay_tilt)
+    {
+        const int i = blockIdx.x*blockDim.x + threadIdx.x;
+        const int j = blockIdx.y*blockDim.y + threadIdx.y;
+        const int k = blockIdx.z*blockDim.z + threadIdx.z;
+
+        if ( (i < n_x) && (j< n_y) && (k < n_z_tilt) )
+        {
+            const int idx  = i + j*n_y + k*n_y*n_x;
+            const Float pos_z = (z_tilt[k] + z_tilt[k+1])/Float(2.);
+            const Float t = interpolate_gpu(n_x, n_y, n_z, z, zh, p_lay, p_lev, i, j, pos_z, tilted_path[k]);
+            t_lay_tilt[idx] = t;
+        }
+    }
+
+    __global__
+    void tilt_layers_gpu(const int n_x, const int n_y, const int n_z,
+                         const ijk* tilted_path,
+                         const Float* v_in, Float* v_tilt)
+    {
+        const int ix = blockIdx.x*blockDim.x + threadIdx.x;
+        const int iy = blockIdx.y*blockDim.y + threadIdx.y;
+        const int iz = blockIdx.z*blockDim.z + threadIdx.z;
+
+        if ( ( ix < n_x) && ( iy < n_y) && (iz < n_z) )
+        {
+            const ijk offset = tilted_path[iz];
+
+            const int idx_out  = ix + iy*n_y + iz*n_y*n_x;
+            const int idx_in = (ix + offset.i)%n_x + (iy+offset.j)%n_y * n_x + offset.k*n_y*n_x;
+
+            v_tilt[idx_out] = v_in[idx_in];
+
+        }
+    }
+
+    __global__
+    void tilt_clouds_gpu(const int n_x, const int n_y, const int n_z,
+                                      const ijk* tilted_path, const Float* zh,
+                                      const Float* water_path, const Float* effective_size,
+                                      Float* water_path_tmp, Float* effective_size_tmp)
+    {
+        const int ix = blockIdx.x*blockDim.x + threadIdx.x;
+        const int iy = blockIdx.y*blockDim.y + threadIdx.y;
+        const int iz = blockIdx.z*blockDim.z + threadIdx.z;
+
+        if ( ( ix < n_x) && ( iy < n_y) && (iz < n_z) )
+        {
+            const ijk offset = tilted_path[iz];
+
+            const int idx_out  = ix + iy*n_y + iz*n_y*n_x;
+            const int idx_in = (ix + offset.i)%n_x + (iy+offset.j)%n_y * n_x + offset.k*n_y*n_x;
+
+            const Float dz_local =  zh[offset.k+1] - zh[offset.k];
+
+            water_path_tmp[idx_out] = water_path[idx_in]/dz_local;
+            effective_size_tmp[idx_out] = effective_size[idx_in];
+
+        }
+    }
+
+    __global__
+    void compress_tilted_clouds_gpu(const int n_x, const int n_y, const int n_z,
+                                      const int* tilted_path_bounds, const Float* zh,
+                                      const Float eff_size_min, const Float eff_size_max,
+                                      const Float* water_path_tmp, const Float* effective_size_tmp,
+                                      Float* water_path, Float* effective_size)
+    {
+        const int ix = blockIdx.x*blockDim.x + threadIdx.x;
+        const int iy = blockIdx.y*blockDim.y + threadIdx.y;
+        const int iz = blockIdx.z*blockDim.z + threadIdx.z;
+
+        if ( ( ix < n_x) && ( iy < n_y) && (iz < n_z) )
+        {
+            const int i_lwr = tilted_path_bounds[iz];
+            const int i_upr = tilted_path_bounds[iz+1];
+
+            Float t_sum = 0.0;
+            Float sum = 0.0;
+            Float w_sum = 0.0;
+            Float avg = 0.0;
+
+            const int idx_out  = ix + iy*n_y + iz*n_y*n_x;
+
+            for (int i = i_lwr; i<i_upr; ++i)
+            {
+                int in_idx = ix + iy * n_x + i * n_x * n_y;
+
+                const Float dz_local =  zh[i+1] - zh[i];
+
+                sum += water_path_tmp[in_idx] * dz_local;
+
+                t_sum += effective_size_tmp[in_idx] * water_path_tmp[in_idx];
+                w_sum += water_path_tmp[in_idx];
+            }
+
+            water_path[idx_out] = sum;
+            if (w_sum > Float(1e-6))
+                effective_size[idx_out] = max(eff_size_min, min(t_sum / w_sum, eff_size_max));
+            else
+                effective_size[idx_out] = eff_size_min;
+
+        }
+    }
+
+    __global__
+    void compress_tilted_columns_gpu(const int n_x, const int n_y, const int n_z,
+                                      const int* tilted_path_bounds,
+                                      const Float* v_tilt, const Float* p_lev_tilt,
+                                      Float* v_out)
+    {
+        const int ix = blockIdx.x*blockDim.x + threadIdx.x;
+        const int iy = blockIdx.y*blockDim.y + threadIdx.y;
+        const int iz = blockIdx.z*blockDim.z + threadIdx.z;
+
+        if ( ( ix < n_x) && ( iy < n_y) && (iz < n_z) )
+        {
+            const int i_lwr = tilted_path_bounds[iz];
+            const int i_upr = tilted_path_bounds[iz+1];
+
+            Float v_sum = Float(0.);
+            Float p_sum = Float(0.);
+
+            const int idx_out  = ix + iy*n_y + iz*n_y*n_x;
+
+            for (int i = i_lwr; i<i_upr; ++i)
+            {
+                int in_idx = ix + iy * n_x + i * n_x * n_y;
+
+                const Float dp_local =  p_lev_tilt[i+1] - p_lev_tilt[i];
+
+                v_sum += v_tilt[in_idx] * dp_local;
+                p_sum += dp_local;
+            }
+
+            v_out[idx_out] = v_sum / p_sum;
+
+        }
+    }
+
+    __global__
+    void compute_rh(const int n_x, const int n_y, const int n_z,
+                    const Float* t_lay,
+                    const Float* p_lay,
+                    const Float* h2o_vmr,
+                    Float* rh)
+    {
+        const int ix = blockIdx.x*blockDim.x + threadIdx.x;
+        const int iy = blockIdx.y*blockDim.y + threadIdx.y;
+        const int iz = blockIdx.z*blockDim.z + threadIdx.z;
+
+        if ( ( ix < n_x) && ( iy < n_y) && (iz < n_z) )
+        {
+            const int idx  = ix + iy*n_y + iz*n_y*n_x;
+
+            const Float qsat = t_lay[idx] > Float(273.16) ? qsat_liq(p_lay[idx], t_lay[idx]) : qsat_ice(p_lay[idx], t_lay[idx]);
+
+            constexpr Float eps = Float(0.62185985592);
+
+            const Float q = h2o_vmr[idx] * eps / (1 + h2o_vmr[idx] * eps);
+
+            rh[idx] = q / qsat;
+
+        }
+    }
+
+
+
+
+}
+
+void tica_tilt_gpu(
+        const Float sza, const Float azi,
+        const int n_col_x, const int n_col_y, const int n_col,
+        const int n_lay, const int n_lev, const int n_z_in, const int n_zh_in ,
+        Array<Float,1>& xh, Array<Float,1>& yh, Array<Float,1>& zh, Array<Float,1>& z,
+        Array_gpu<Float,2>& p_lay, Array_gpu<Float,2>& t_lay, Array_gpu<Float,2>& p_lev, Array_gpu<Float,2>& t_lev,
+        Array_gpu<Float,2>& lwp, Array_gpu<Float,2>& iwp, Array_gpu<Float,2>& rel, Array_gpu<Float,2>& dei, Array_gpu<Float,2>& rh,
+        Gas_concs_gpu& gas_concs, Aerosol_concs_gpu& aerosol_concs,
+        std::vector<std::string>& gas_names, std::vector<std::string>& aerosol_names,
+        bool switch_cloud_optics, bool switch_liq_cloud_optics, bool switch_ice_cloud_optics, bool switch_aerosol_optics,
+        int rnd_seed)
+{
+
+    // TODO: move interpolation from T_lay to T_lev to input
+
+    Array<Float,2> t_lev_tmp({n_col, n_lev});
+
+    if (*std::max_element(t_lev_tmp.v().begin(), t_lev_tmp.v().end()) <= 0) {
+        for (int i = 1; i <= n_col; ++i) {
+            for (int j = 2; j <= n_lay; ++j) {
+                t_lev_tmp({i, j}) = (t_lay({i, j}) + t_lay({i, j - 1})) / 2.0;
+            }
+            t_lev_tmp({i, n_lev}) = 2 * t_lay({i, n_lay}) - t_lev_tmp({i,n_lay});
+            t_lev_tmp({i, 1}) = 2 * t_lay({i, 1}) - t_lev_tmp({i,2});
+        }
+    }
+
+    // copy interpolated values into t_lev too
+    t_lev = t_lev_tmp;
+
+    ////// SETUP FOR CENTER START POINT TILTING //////
+    // Finding tilted path can stay on CPU
+    Array<ijk,1> center_path;
+    Array<Float,1> center_zh_tilt;
+    create_tilted_path(xh.v(),yh.v(),zh.v(),z.v(),sza,azi, 0.5, 0.5, center_path.v(), center_zh_tilt.v());
+
+
+    int n_zh_tilt_center = center_zh_tilt.v().size();
+    int n_z_tilt_center = n_zh_tilt_center - 1;
+
+    center_path.set_dims({n_zh_tilt_center});
+    center_zh_tilt.set_dims({n_zh_tilt_center});
+
+    Array<int,1> center_path_bounds({n_zh_in});
+    get_tilted_path_bounds(n_z_tilt_center, center_path.v(), center_path_bounds.v());
+
+    Array_gpu<ijk,1> center_path_gpu(center_path);
+    Array_gpu<Float,1> center_zh_tilt_gpu(center_zh_tilt);
+    Array_gpu<int,1> center_path_bounds_gpu(center_path_bounds);
+    Array_gpu<Float,1> zh_gpu(zh);
+    Array_gpu<Float,1> z_gpu(z);
+
+    // p_lay and p_lev remain unchanged after tiltint and compression.
+    // However, we need to obtain the pressures at each cell crossing of the tilted path to use for weighted averaging
+    Array_gpu<Float,1> p_lev_tilt({n_zh_tilt_center});
+
+    const int block_col_x = 8;
+    const int block_col_y = 8;
+    const int block_z_in = 4;
+    const int block_z_tilt = 4;
+    const int block_zh_tilt = 4;
+
+    const int grid_col_x = n_col_x/block_col_x + (n_col_x%block_col_x > 0);
+    const int grid_col_y = n_col_y/block_col_y + (n_col_y%block_col_y > 0);
+    const int grid_z_in = n_z_in/block_z_in + (n_z_in%block_z_in > 0);
+    const int grid_z_tilt = n_z_tilt_center/block_z_tilt + (n_z_tilt_center%block_z_tilt > 0);
+    const int grid_zh_tilt = n_zh_tilt_center/block_zh_tilt + (n_zh_tilt_center%block_zh_tilt > 0);
+
+    dim3 grid_1d(grid_zh_tilt);
+    dim3 block_1d(block_zh_tilt);
+
+    dim3 grid_3d_1(grid_col_x, grid_col_y, grid_z_in);
+    dim3 block_3d_1(block_col_x, block_col_y, block_z_in);
+
+    dim3 grid_3d_2(grid_col_x, grid_col_y, grid_z_tilt);
+    dim3 block_3d_2(block_col_x, block_col_y, block_z_tilt);
+
+    tilt_plev_gpu<<<grid_1d, block_1d>>>(
+            n_col_x, n_col_y, n_z_in, n_z_tilt_center,
+            center_path_gpu.ptr(),
+            center_zh_tilt_gpu.ptr(), z_gpu.ptr(), zh_gpu.ptr(),
+            p_lay.ptr(), p_lev.ptr(),
+            p_lev_tilt.ptr() );
+
+    // T_lev remains unchanged after tilting and compression.
+    // T_lay is first to z_tilt and then compressed
+
+    Array_gpu<Float,2> t_lay_tilt({n_col, n_z_tilt_center});
+
+    tilt_tlay_gpu<<<grid_3d_2, block_3d_2>>>(
+        n_col_x, n_col_y, n_z_in, n_z_tilt_center,
+        center_path_gpu.ptr(),
+        center_zh_tilt_gpu.ptr(), z_gpu.ptr(), zh_gpu.ptr(),
+        t_lay.ptr(), t_lev.ptr(),
+        t_lay_tilt.ptr() );
+
+    compress_tilted_columns_gpu<<<grid_3d_1, block_3d_1>>>(
+        n_col_x, n_col_y, n_z_in,
+        center_path_bounds_gpu.ptr(),
+        t_lay_tilt.ptr(), p_lev_tilt.ptr(),
+        t_lay.ptr());
+
+
+    //// tilt and compress gasses ////
+    Array_gpu<Float,2> gas_tilt({n_col, n_z_tilt_center});
+    Array_gpu<Float,2> gas_new({n_col, n_z_in});
+
+    for (const auto& gas_name : gas_names)
+    {
+        if (!gas_concs.exists(gas_name))
+        {
+            continue;
+        }
+
+        const Array_gpu<Float,2>& gas = gas_concs.get_vmr(gas_name);
+        if (gas.size() > 1)
+        {
+            if (gas.get_dims()[0] > 1)
+            { // checking: do we have 3D field?
+                tilt_layers_gpu<<<grid_3d_2, block_3d_2>>>(
+                        n_col_x, n_col_y, n_z_tilt_center,
+                        center_path_gpu.ptr(),
+                        gas.ptr(), gas_tilt.ptr());
+
+                compress_tilted_columns_gpu<<<grid_3d_1, block_3d_1>>>(
+                        n_col_x, n_col_y, n_z_in,
+                        center_path_bounds_gpu.ptr(),
+                        gas_tilt.ptr(), p_lev_tilt.ptr(),
+                        gas_new.ptr());
+
+                gas_concs.set_vmr(gas_name, gas_new);
+            }
+            else
+            {
+                throw std::runtime_error("No tilted column implementation for single column profiles.");
+            }
+            if ( (gas_name == "h2o") && switch_aerosol_optics )
+            {
+                compute_rh<<<grid_3d_1, block_3d_1>>>(
+                        n_col_x, n_col_y, n_z_in,
+                        t_lay.ptr(),
+                        p_lay.ptr(),
+                        gas_new.ptr(),
+                        rh.ptr());
+            }
+        }
+    }
+
+    if (switch_aerosol_optics)
+    {
+        Array_gpu<Float,2> aerosol_tilt({n_col, n_z_tilt_center});
+        Array_gpu<Float,2> aerosol_new({n_col, n_z_in});
+
+        for (const auto& aerosol_name : aerosol_names)
+        {
+            if (!aerosol_concs.exists(aerosol_name))
+            {
+                continue;
+            }
+
+            const Array_gpu<Float,2>& aerosol = aerosol_concs.get_vmr(aerosol_name);
+            if (aerosol.size() > 1)
+            {
+                if (aerosol.get_dims()[0] > 1)
+                { // checking: do we have 3D field?
+                    tilt_layers_gpu<<<grid_3d_2, block_3d_2>>>(
+                            n_col_x, n_col_y, n_z_tilt_center,
+                            center_path_gpu.ptr(),
+                            aerosol.ptr(), aerosol_tilt.ptr());
+
+                    compress_tilted_columns_gpu<<<grid_3d_1, block_3d_1>>>(
+                            n_col_x, n_col_y, n_z_in,
+                            center_path_bounds_gpu.ptr(),
+                            aerosol_tilt.ptr(), p_lev_tilt.ptr(),
+                            aerosol_new.ptr());
+
+                    aerosol_concs.set_vmr(aerosol_name, aerosol_new);
+                }
+                else
+                {
+                    throw std::runtime_error("No tilted column implementation for single column profiles.");
+                }
+            }
+        }
+    }
+
+
+
+
+    /*
+
+    // first function to move to GPU
+    tilt_and_compress_fields(n_z_in, n_zh_in, n_col_x, n_col_y,
+                n_z_tilt_center, n_zh_tilt_center, n_col,
+                zh, z,
+                center_zh_tilt, center_path,
+                &p_lay_out, &t_lay_out, &p_lev_out, &t_lev_out, &rh_out,
+                gas_concs_out, gas_names, aerosol_concs_out, aerosol_names, switch_aerosol_optics
+    );
+
+    const int n_lay_tilt = center_path.size();
+
+    Array_gpu<Float,2> lwp_tmp({n_col, n_lay_tilt});
+    Array_gpu<Float,2> rel_tmp({n_col, n_lay_tilt});
+    Array_gpu<Float,2> iwp_tmp({n_col, n_lay_tilt});
+    Array_gpu<Float,2> dei_tmp({n_col, n_lay_tilt});
+    */
+    ////// clouds //////
+
+
+    if (switch_cloud_optics)
+    {
+
+        Array_gpu<Float,2> lwp_tmp({n_col, n_z_tilt_center});
+        Array_gpu<Float,2> rel_tmp({n_col, n_z_tilt_center});
+        Array_gpu<Float,2> iwp_tmp({n_col, n_z_tilt_center});
+        Array_gpu<Float,2> dei_tmp({n_col, n_z_tilt_center});
+
+        if (switch_liq_cloud_optics)
+        {
+            tilt_clouds_gpu<<<grid_3d_2, block_3d_2>>>(n_col_x, n_col_y, n_z_tilt_center,
+                                         center_path_gpu.ptr(), zh_gpu.ptr(),
+                                         lwp.ptr(), rel.ptr(),
+                                         lwp_tmp.ptr(), rel_tmp.ptr());
+
+            compress_tilted_clouds_gpu<<<grid_3d_1, block_3d_1>>>(n_col_x, n_col_y, n_z_in,
+                                               center_path_bounds_gpu.ptr(), center_zh_tilt_gpu.ptr(),
+                                               Float(2.5), Float(21.5),
+                                               lwp_tmp.ptr(), rel_tmp.ptr(),
+                                               lwp.ptr(), rel.ptr());
+
+        }
+
+        if (switch_ice_cloud_optics)
+        {
+            tilt_clouds_gpu<<<grid_3d_2, block_3d_2>>>(n_col_x, n_col_y, n_z_tilt_center,
+                                         center_path_gpu.ptr(), zh_gpu.ptr(),
+                                         iwp.ptr(), dei.ptr(),
+                                         iwp_tmp.ptr(), dei_tmp.ptr());
+
+            compress_tilted_clouds_gpu<<<grid_3d_1, block_3d_1>>>(n_col_x, n_col_y, n_z_in,
+                                               center_path_bounds_gpu.ptr(), center_zh_tilt_gpu.ptr(),
+                                               Float(10), Float(180.),
+                                               iwp_tmp.ptr(), dei_tmp.ptr(),
+                                               iwp.ptr(), dei.ptr());
+
+        }
+
+    }
+/*
+        post_process_output(col_results, n_col_x, n_col_y, n_z_in, n_zh_in,
+                            &lwp_out, &iwp_out, &rel_out, &dei_out,
+                            switch_liq_cloud_optics, switch_ice_cloud_optics);
+
+
+
+    restore_bkg_profile_bundle(n_col_x, n_col_y,
+                               n_lay, n_lev, n_lay, n_lev,
+                               n_z_in, n_zh_in, n_z_in, n_zh_in,
+                               &p_lay_out, &t_lay_out, &p_lev_out, &t_lev_out,
+                               &lwp_out, &iwp_out, &rel_out, &dei_out, &rh_out,
+                               gas_concs_out, aerosol_concs_out,
+                               &p_lay, &t_lay, &p_lev, &t_lev,
+                               &lwp, &iwp, &rel, &dei, &rh,
+                               gas_concs, aerosol_concs,
+                               gas_names, aerosol_names,
+                               switch_liq_cloud_optics, switch_ice_cloud_optics, switch_aerosol_optics
+    );
+    */
+}
+

--- a/src_tilt/tilt_utils.cu
+++ b/src_tilt/tilt_utils.cu
@@ -304,24 +304,6 @@ void tica_tilt_gpu(
         bool switch_cloud_optics, bool switch_liq_cloud_optics, bool switch_ice_cloud_optics, bool switch_aerosol_optics,
         int rnd_seed)
 {
-
-    // TODO: move interpolation from T_lay to T_lev to input
-
-    Array<Float,2> t_lev_tmp({n_col, n_lev});
-
-    if (*std::max_element(t_lev_tmp.v().begin(), t_lev_tmp.v().end()) <= 0) {
-        for (int i = 1; i <= n_col; ++i) {
-            for (int j = 2; j <= n_lay; ++j) {
-                t_lev_tmp({i, j}) = (t_lay({i, j}) + t_lay({i, j - 1})) / 2.0;
-            }
-            t_lev_tmp({i, n_lev}) = 2 * t_lay({i, n_lay}) - t_lev_tmp({i,n_lay});
-            t_lev_tmp({i, 1}) = 2 * t_lay({i, 1}) - t_lev_tmp({i,2});
-        }
-    }
-
-    // copy interpolated values into t_lev too
-    t_lev = t_lev_tmp;
-
     ////// SETUP FOR CENTER START POINT TILTING //////
     // Finding tilted path can stay on CPU
     Array<ijk,1> center_path;
@@ -393,8 +375,6 @@ void tica_tilt_gpu(
         center_path_bounds_gpu.ptr(),
         t_lay_tilt.ptr(), p_lev_tilt.ptr(),
         t_lay.ptr());
-
-    t_lay.dump("t_lay");
 
     //// tilt and compress gasses ////
     Array_gpu<Float,2> gas_tilt({n_col, n_z_tilt_center});

--- a/src_tilt/tilt_utils.cu
+++ b/src_tilt/tilt_utils.cu
@@ -424,7 +424,6 @@ void tica_tilt_gpu(
     if (switch_aerosol_optics)
     {
         Array_gpu<Float,2> aerosol_tilt({n_col, n_z_tilt_center});
-        //Array_gpu<Float,2> aerosol_new({n_col, n_z_in});
 
         for (const auto& aerosol_name : aerosol_names)
         {
@@ -455,29 +454,6 @@ void tica_tilt_gpu(
             }
         }
     }
-
-
-
-
-    /*
-
-    // first function to move to GPU
-    tilt_and_compress_fields(n_z_in, n_zh_in, n_col_x, n_col_y,
-                n_z_tilt_center, n_zh_tilt_center, n_col,
-                zh, z,
-                center_zh_tilt, center_path,
-                &p_lay_out, &t_lay_out, &p_lev_out, &t_lev_out, &rh_out,
-                gas_concs_out, gas_names, aerosol_concs_out, aerosol_names, switch_aerosol_optics
-    );
-
-    const int n_lay_tilt = center_path.size();
-
-    Array_gpu<Float,2> lwp_tmp({n_col, n_lay_tilt});
-    Array_gpu<Float,2> rel_tmp({n_col, n_lay_tilt});
-    Array_gpu<Float,2> iwp_tmp({n_col, n_lay_tilt});
-    Array_gpu<Float,2> dei_tmp({n_col, n_lay_tilt});
-    */
-    ////// clouds //////
 
 
     if (switch_cloud_optics)
@@ -519,25 +495,5 @@ void tica_tilt_gpu(
         }
 
     }
-/*
-        post_process_output(col_results, n_col_x, n_col_y, n_z_in, n_zh_in,
-                            &lwp_out, &iwp_out, &rel_out, &dei_out,
-                            switch_liq_cloud_optics, switch_ice_cloud_optics);
-
-
-
-    restore_bkg_profile_bundle(n_col_x, n_col_y,
-                               n_lay, n_lev, n_lay, n_lev,
-                               n_z_in, n_zh_in, n_z_in, n_zh_in,
-                               &p_lay_out, &t_lay_out, &p_lev_out, &t_lev_out,
-                               &lwp_out, &iwp_out, &rel_out, &dei_out, &rh_out,
-                               gas_concs_out, aerosol_concs_out,
-                               &p_lay, &t_lay, &p_lev, &t_lev,
-                               &lwp, &iwp, &rel, &dei, &rh,
-                               gas_concs, aerosol_concs,
-                               gas_names, aerosol_names,
-                               switch_liq_cloud_optics, switch_ice_cloud_optics, switch_aerosol_optics
-    );
-    */
 }
 

--- a/src_tilt/tilt_utils.cu
+++ b/src_tilt/tilt_utils.cu
@@ -15,6 +15,7 @@
 #include "tilt_utils.h"
 #include "types.h"
 
+#include "gas_optics_rrtmgp_kernels_cuda_rt.h"
 
 namespace
 {
@@ -98,7 +99,7 @@ namespace
 
 
     __global__
-    void tilt_plev_gpu(const int n_x, const int n_y, const int n_z, const int n_z_tilt,
+    void tilt_plev_gpu(const int n_x, const int n_y, const int n_z, const int n_z_tilted,
                        const ijk* tilted_path,
                        const Float* zh_tilt,
                        const Float* z, const Float* zh,
@@ -107,7 +108,7 @@ namespace
     {
         const int i = blockIdx.x*blockDim.x + threadIdx.x;
 
-        if ( (i < (n_z_tilt+1) ) )
+        if ( (i < (n_z_tilted+1) ) )
         {
             const Float pos_z = zh_tilt[i];
             const Float p = interpolate_gpu(n_x, n_y, n_z, z, zh, p_lay, p_lev, 0, 0, pos_z, tilted_path[i]);
@@ -116,7 +117,7 @@ namespace
     }
 
     __global__
-    void tilt_tlay_gpu(const int n_x, const int n_y, const int n_z, const int n_z_tilt,
+    void tilt_tlay_gpu(const int n_x, const int n_y, const int n_z, const int n_z_tilted,
                        const ijk* tilted_path,
                        const Float* z_tilt,
                        const Float* z, const Float* zh,
@@ -127,7 +128,7 @@ namespace
         const int j = blockIdx.y*blockDim.y + threadIdx.y;
         const int k = blockIdx.z*blockDim.z + threadIdx.z;
 
-        if ( (i < n_x) && (j< n_y) && (k < n_z_tilt) )
+        if ( (i < n_x) && (j< n_y) && (k < n_z_tilted) )
         {
             const int idx  = i + j*n_y + k*n_y*n_x;
             const Float pos_z = (z_tilt[k] + z_tilt[k+1])/Float(2.);
@@ -262,6 +263,171 @@ namespace
     }
 
     __global__
+    void translate_twostream_fluxes_gpu(const int n_x, const int n_y, const int n_z, const int n_lev_in,
+                          const ijk* tilted_path,
+                          const int* tilted_path_bounds,
+                          const Float* flux_in,
+                          Float* flux_out)
+    {
+        const int ix = blockIdx.x*blockDim.x + threadIdx.x;
+        const int iy = blockIdx.y*blockDim.y + threadIdx.y;
+        const int iz = blockIdx.z*blockDim.z + threadIdx.z;
+
+        if ( ( ix < n_x) && ( iy < n_y) && (iz < n_z) )
+        {
+            const int i_tilt = tilted_path_bounds[iz];
+            const ijk offset = tilted_path[i_tilt];
+
+            const int idx_out = ix + iy * n_x + iz * n_y * n_x;
+            const int modulo_x = ix - offset.i < 0 ? (ix - offset.i)% n_x + n_x: (ix - offset.i)% n_x;
+            const int modulo_y = iy - offset.j < 0 ? (iy - offset.j)% n_y + n_y: (iy - offset.j)% n_y;
+            const int idx_in = modulo_x + modulo_y * n_x + iz * n_y * n_x;
+            flux_out[idx_out] = flux_in[idx_in];
+        }
+        else if ( ( ix < n_x) && ( iy < n_y) && (iz < n_lev_in) )
+        {
+            const int i_tilt = tilted_path_bounds[n_z];
+            const ijk offset_tod = tilted_path[i_tilt];
+            const int idx_out = ix + iy * n_x + iz * n_y * n_x;
+            const int modulo_x = ix - offset_tod.i < 0 ? (ix - offset_tod.i)% n_x + n_x: (ix - offset_tod.i)% n_x;
+            const int modulo_y = iy - offset_tod.j < 0 ? (iy - offset_tod.j)% n_y + n_y: (iy - offset_tod.j)% n_y;
+            const int idx_in = modulo_x + modulo_y * n_x + iz * n_y * n_x;
+            flux_out[idx_out] = flux_in[idx_in];
+        }
+    }
+
+
+    __global__
+    void translate_absorption_gpu(const int n_x, const int n_y,
+                          const int n_z_in, const int n_z,
+                          const ijk* tilted_path,
+                          const int* tilted_path_bounds,
+                          const Float* p_lev_tilt,
+                          const Float* abs_in,
+                          Float* abs_out)
+    {
+        const int ix = blockIdx.x*blockDim.x + threadIdx.x;
+        const int iy = blockIdx.y*blockDim.y + threadIdx.y;
+        const int iz = blockIdx.z*blockDim.z + threadIdx.z;
+
+        if ( ( ix < n_x) && ( iy < n_y) && (iz < n_z) )
+        {
+            if (iz < n_z_in)
+            {
+                const int i_tilt_lwr = tilted_path_bounds[iz];
+                const int i_tilt_upr = tilted_path_bounds[iz+1];
+                const Float dp_total = p_lev_tilt[i_tilt_lwr] - p_lev_tilt[i_tilt_upr];
+
+                for (int i_tilt = i_tilt_lwr; i_tilt < i_tilt_upr; ++i_tilt)
+                {
+                    const Float dp_local = p_lev_tilt[i_tilt] - p_lev_tilt[i_tilt + 1];
+
+                    const ijk offset = tilted_path[i_tilt];
+
+                    const int idx_out = ix + iy * n_x + iz * n_y * n_x;
+                    const int modulo_x = ix - offset.i < 0 ? (ix - offset.i)% n_x + n_x: (ix - offset.i)% n_x;
+                    const int modulo_y = iy - offset.j < 0 ? (iy - offset.j)% n_y + n_y: (iy - offset.j)% n_y;
+                    const int idx_in = modulo_x + modulo_y * n_x + iz * n_y * n_x;
+                    abs_out[idx_out] += abs_in[idx_in] * dp_local / dp_total;
+                }
+            }
+            else
+            {
+                const int i_tilt = tilted_path_bounds[n_z_in];
+                const ijk offset = tilted_path[i_tilt];
+
+                const int idx_out = ix + iy * n_x + iz * n_y * n_x;
+                const int modulo_x = ix - offset.i < 0 ? (ix - offset.i)% n_x + n_x: (ix - offset.i)% n_x;
+                const int modulo_y = iy - offset.j < 0 ? (iy - offset.j)% n_y + n_y: (iy - offset.j)% n_y;
+                const int idx_in = modulo_x + modulo_y * n_x + iz * n_y * n_x;
+                abs_out[idx_out] += abs_in[idx_in];
+
+
+            }
+        }
+    }
+
+    __global__
+    void translate_toa_flux_gpu(const int n_x, const int n_y,
+                          const int n_zh_tilt,
+                          const ijk* tilted_path,
+                          const int* tilted_path_bounds,
+                          const Float* abs_in,
+                          Float* abs_out)
+    {
+        const int ix = blockIdx.x*blockDim.x + threadIdx.x;
+        const int iy = blockIdx.y*blockDim.y + threadIdx.y;
+
+        if ( ( ix < n_x) && ( iy < n_y) )
+        {
+            const ijk offset = tilted_path[n_zh_tilt-1];
+
+            const int idx_out = ix + iy * n_x;
+            const int modulo_x = ix - offset.i < 0 ? (ix - offset.i)% n_x + n_x: (ix - offset.i)% n_x;
+            const int modulo_y = iy - offset.j < 0 ? (iy - offset.j)% n_y + n_y: (iy - offset.j)% n_y;
+            const int idx_in = modulo_x + modulo_y * n_x;
+            abs_out[idx_out] = abs_in[idx_in];
+
+        }
+    }
+template<typename TF> __global__
+    void get_mean_profile(
+            TF* const __restrict__ prof,
+            const TF* const __restrict__ fld,
+            const TF scalefac,
+            const int istart, const int iend,
+            const int jstart, const int jend,
+            const int kcells,
+            const int icells, const int ijcells)
+    {
+        const int i = blockIdx.x*blockDim.x + threadIdx.x + istart;
+        const int j = blockIdx.y*blockDim.y + threadIdx.y + jstart;
+        const int k = blockIdx.z;
+
+        if (i < iend && j < jend && k < kcells)
+        {
+            const int ijk = i + j*icells + k*ijcells;
+            atomicAdd(&prof[k], fld[ijk]*scalefac);
+        }
+    }
+
+    __global__
+    void tica_mean_profile(const int n_x, const int n_y, const int n_z,
+                           const Float n_col_inv,
+                           const Float* field,
+                           Float* profile)
+    {
+        const int ix = blockIdx.x*blockDim.x + threadIdx.x;
+        const int iy = blockIdx.y*blockDim.y + threadIdx.y;
+        const int iz = blockIdx.z*blockDim.z + threadIdx.z;
+
+        if ( ( ix < n_x) && ( iy < n_y) && (iz < n_z) )
+        {
+            const int idx  = ix + iy*n_y + iz*n_y*n_x;
+            atomicAdd(&profile[iz], field[idx] * n_col_inv);
+        }
+
+    }
+
+    __global__
+    void tica_profile_to_3d(const int n_x, const int n_y, const int n_z,
+                            const Float n_col_inv,
+                            const Float* profile,
+                            Float* field)
+    {
+        const int ix = blockIdx.x*blockDim.x + threadIdx.x;
+        const int iy = blockIdx.y*blockDim.y + threadIdx.y;
+        const int iz = blockIdx.z*blockDim.z + threadIdx.z;
+
+        if ( ( ix < n_x) && ( iy < n_y) && (iz < n_z) )
+        {
+            const int idx  = ix + iy*n_y + iz*n_y*n_x;
+            field[idx] = profile[iz];
+        }
+    }
+
+
+    __global__
     void compute_rh(const int n_x, const int n_y, const int n_z,
                     const Float* t_lay,
                     const Float* p_lay,
@@ -296,40 +462,21 @@ void tica_tilt_gpu(
         const Float sza, const Float azi,
         const int n_col_x, const int n_col_y, const int n_col,
         const int n_lay, const int n_lev, const int n_z_in, const int n_zh_in ,
-        Array<Float,1>& xh, Array<Float,1>& yh, Array<Float,1>& zh, Array<Float,1>& z,
+        const Array_gpu<Float,1>& z, const Array_gpu<Float,1>& zh,
         Array_gpu<Float,2>& p_lay, Array_gpu<Float,2>& t_lay, Array_gpu<Float,2>& p_lev, Array_gpu<Float,2>& t_lev,
         Array_gpu<Float,2>& lwp, Array_gpu<Float,2>& iwp, Array_gpu<Float,2>& rel, Array_gpu<Float,2>& dei, Array_gpu<Float,2>& rh,
+        const Array_gpu<ijk,1>& tilted_path, const Array_gpu<int,1>& tilted_path_bounds,
+        const Array_gpu<Float,1>& zh_tilted, Array_gpu<Float,1>& p_lev_tilt,
         Gas_concs_gpu& gas_concs, Aerosol_concs_gpu& aerosol_concs,
         std::vector<std::string>& gas_names, std::vector<std::string>& aerosol_names,
         bool switch_cloud_optics, bool switch_liq_cloud_optics, bool switch_ice_cloud_optics, bool switch_aerosol_optics,
         int rnd_seed)
 {
-    ////// SETUP FOR CENTER START POINT TILTING //////
-    // Finding tilted path can stay on CPU
-    Array<ijk,1> center_path;
-    Array<Float,1> center_zh_tilt;
-    create_tilted_path(xh.v(),yh.v(),zh.v(),z.v(),sza,azi, 0.5, 0.5, center_path.v(), center_zh_tilt.v());
-
-
-    int n_zh_tilt_center = center_zh_tilt.v().size();
-    int n_z_tilt_center = n_zh_tilt_center - 1;
-
-    center_path.set_dims({n_zh_tilt_center});
-    center_zh_tilt.set_dims({n_zh_tilt_center});
-
-    Array<int,1> center_path_bounds({n_zh_in});
-    get_tilted_path_bounds(n_zh_tilt_center, center_path.v(), center_path_bounds.v());
-
-    Array_gpu<ijk,1> center_path_gpu(center_path);
-    Array_gpu<Float,1> center_zh_tilt_gpu(center_zh_tilt);
-    Array_gpu<int,1> center_path_bounds_gpu(center_path_bounds);
-    Array_gpu<Float,1> zh_gpu(zh);
-    Array_gpu<Float,1> z_gpu(z);
+    int n_zh_tilted = tilted_path.size();
+    int n_z_tilted = n_zh_tilted - 1;
 
     // p_lay and p_lev remain unchanged after tiltint and compression.
     // However, we need to obtain the pressures at each cell crossing of the tilted path to use for weighted averaging
-    Array_gpu<Float,1> p_lev_tilt({n_zh_tilt_center});
-
     const int block_col_x = 8;
     const int block_col_y = 8;
     const int block_z_in = 4;
@@ -339,8 +486,8 @@ void tica_tilt_gpu(
     const int grid_col_x = n_col_x/block_col_x + (n_col_x%block_col_x > 0);
     const int grid_col_y = n_col_y/block_col_y + (n_col_y%block_col_y > 0);
     const int grid_z_in = n_z_in/block_z_in + (n_z_in%block_z_in > 0);
-    const int grid_z_tilt = n_z_tilt_center/block_z_tilt + (n_z_tilt_center%block_z_tilt > 0);
-    const int grid_zh_tilt = n_zh_tilt_center/block_zh_tilt + (n_zh_tilt_center%block_zh_tilt > 0);
+    const int grid_z_tilt = n_z_tilted/block_z_tilt + (n_z_tilted%block_z_tilt > 0);
+    const int grid_zh_tilt = n_zh_tilted/block_zh_tilt + (n_zh_tilted%block_zh_tilt > 0);
 
     dim3 grid_1d(grid_zh_tilt);
     dim3 block_1d(block_zh_tilt);
@@ -352,32 +499,32 @@ void tica_tilt_gpu(
     dim3 block_3d_2(block_col_x, block_col_y, block_z_tilt);
 
     tilt_plev_gpu<<<grid_1d, block_1d>>>(
-            n_col_x, n_col_y, n_z_in, n_z_tilt_center,
-            center_path_gpu.ptr(),
-            center_zh_tilt_gpu.ptr(), z_gpu.ptr(), zh_gpu.ptr(),
+            n_col_x, n_col_y, n_z_in, n_z_tilted,
+            tilted_path.ptr(),
+            zh_tilted.ptr(), z.ptr(), zh.ptr(),
             p_lay.ptr(), p_lev.ptr(),
             p_lev_tilt.ptr() );
 
     // T_lev remains unchanged after tilting and compression.
     // T_lay is first to z_tilt and then compressed
 
-    Array_gpu<Float,2> t_lay_tilt({n_col, n_z_tilt_center});
+    Array_gpu<Float,2> t_lay_tilt({n_col, n_z_tilted});
 
     tilt_tlay_gpu<<<grid_3d_2, block_3d_2>>>(
-        n_col_x, n_col_y, n_z_in, n_z_tilt_center,
-        center_path_gpu.ptr(),
-        center_zh_tilt_gpu.ptr(), z_gpu.ptr(), zh_gpu.ptr(),
+        n_col_x, n_col_y, n_z_in, n_z_tilted,
+        tilted_path.ptr(),
+        zh_tilted.ptr(), z.ptr(), zh.ptr(),
         t_lay.ptr(), t_lev.ptr(),
         t_lay_tilt.ptr() );
 
     compress_tilted_columns_gpu<<<grid_3d_1, block_3d_1>>>(
         n_col_x, n_col_y, n_z_in,
-        center_path_bounds_gpu.ptr(),
+        tilted_path_bounds.ptr(),
         t_lay_tilt.ptr(), p_lev_tilt.ptr(),
         t_lay.ptr());
 
     //// tilt and compress gasses ////
-    Array_gpu<Float,2> gas_tilt({n_col, n_z_tilt_center});
+    Array_gpu<Float,2> gas_tilt({n_col, n_z_tilted});
 
     for (const auto& gas_name : gas_names)
     {
@@ -392,13 +539,13 @@ void tica_tilt_gpu(
             if (gas.get_dims()[0] > 1)
             { // checking: do we have 3D field?
                 tilt_layers_gpu<<<grid_3d_2, block_3d_2>>>(
-                        n_col_x, n_col_y, n_z_tilt_center,
-                        center_path_gpu.ptr(),
+                        n_col_x, n_col_y, n_z_tilted,
+                        tilted_path.ptr(),
                         gas.ptr(), gas_tilt.ptr());
 
                 compress_tilted_columns_gpu<<<grid_3d_1, block_3d_1>>>(
                         n_col_x, n_col_y, n_z_in,
-                        center_path_bounds_gpu.ptr(),
+                        tilted_path_bounds.ptr(),
                         gas_tilt.ptr(), p_lev_tilt.ptr(),
                         gas.ptr());
 
@@ -423,7 +570,7 @@ void tica_tilt_gpu(
 
     if (switch_aerosol_optics)
     {
-        Array_gpu<Float,2> aerosol_tilt({n_col, n_z_tilt_center});
+        Array_gpu<Float,2> aerosol_tilt({n_col, n_z_tilted});
 
         for (const auto& aerosol_name : aerosol_names)
         {
@@ -439,13 +586,13 @@ void tica_tilt_gpu(
                 {
                     //  Only tilt if we have a 3D aerosol field
                     tilt_layers_gpu<<<grid_3d_2, block_3d_2>>>(
-                            n_col_x, n_col_y, n_z_tilt_center,
-                            center_path_gpu.ptr(),
+                            n_col_x, n_col_y, n_z_tilted,
+                            tilted_path.ptr(),
                             aerosol.ptr(), aerosol_tilt.ptr());
 
                     compress_tilted_columns_gpu<<<grid_3d_1, block_3d_1>>>(
                             n_col_x, n_col_y, n_z_in,
-                            center_path_bounds_gpu.ptr(),
+                            tilted_path_bounds.ptr(),
                             aerosol_tilt.ptr(), p_lev_tilt.ptr(),
                             aerosol.ptr());
 
@@ -459,20 +606,20 @@ void tica_tilt_gpu(
     if (switch_cloud_optics)
     {
 
-        Array_gpu<Float,2> lwp_tmp({n_col, n_z_tilt_center});
-        Array_gpu<Float,2> rel_tmp({n_col, n_z_tilt_center});
-        Array_gpu<Float,2> iwp_tmp({n_col, n_z_tilt_center});
-        Array_gpu<Float,2> dei_tmp({n_col, n_z_tilt_center});
+        Array_gpu<Float,2> lwp_tmp({n_col, n_z_tilted});
+        Array_gpu<Float,2> rel_tmp({n_col, n_z_tilted});
+        Array_gpu<Float,2> iwp_tmp({n_col, n_z_tilted});
+        Array_gpu<Float,2> dei_tmp({n_col, n_z_tilted});
 
         if (switch_liq_cloud_optics)
         {
-            tilt_clouds_gpu<<<grid_3d_2, block_3d_2>>>(n_col_x, n_col_y, n_z_tilt_center,
-                                         center_path_gpu.ptr(), zh_gpu.ptr(),
+            tilt_clouds_gpu<<<grid_3d_2, block_3d_2>>>(n_col_x, n_col_y, n_z_tilted,
+                                         tilted_path.ptr(), zh.ptr(),
                                          lwp.ptr(), rel.ptr(),
                                          lwp_tmp.ptr(), rel_tmp.ptr());
 
             compress_tilted_clouds_gpu<<<grid_3d_1, block_3d_1>>>(n_col_x, n_col_y, n_z_in,
-                                               center_path_bounds_gpu.ptr(), center_zh_tilt_gpu.ptr(),
+                                               tilted_path_bounds.ptr(), zh_tilted.ptr(),
                                                Float(2.5), Float(21.5),
                                                lwp_tmp.ptr(), rel_tmp.ptr(),
                                                lwp.ptr(), rel.ptr());
@@ -481,13 +628,13 @@ void tica_tilt_gpu(
 
         if (switch_ice_cloud_optics)
         {
-            tilt_clouds_gpu<<<grid_3d_2, block_3d_2>>>(n_col_x, n_col_y, n_z_tilt_center,
-                                         center_path_gpu.ptr(), zh_gpu.ptr(),
+            tilt_clouds_gpu<<<grid_3d_2, block_3d_2>>>(n_col_x, n_col_y, n_z_tilted,
+                                         tilted_path.ptr(), zh.ptr(),
                                          iwp.ptr(), dei.ptr(),
                                          iwp_tmp.ptr(), dei_tmp.ptr());
 
             compress_tilted_clouds_gpu<<<grid_3d_1, block_3d_1>>>(n_col_x, n_col_y, n_z_in,
-                                               center_path_bounds_gpu.ptr(), center_zh_tilt_gpu.ptr(),
+                                               tilted_path_bounds.ptr(), zh_tilted.ptr(),
                                                Float(10), Float(180.),
                                                iwp_tmp.ptr(), dei_tmp.ptr(),
                                                iwp.ptr(), dei.ptr());
@@ -496,4 +643,183 @@ void tica_tilt_gpu(
 
     }
 }
+
+void tica_reverse_gpu(
+        const int n_col_x, const int n_col_y, const int n_lay, const int n_lev,
+        const int n_z, const int n_z_in, const int n_zh_in ,
+        const bool do_tilting, const bool switch_twostream, const bool switch_raytracing,
+        const Array_gpu<Float,1>& zh, const Array_gpu<Float,1>& zh_tilt,
+        const Array_gpu<ijk,1>& tilted_path, const Array_gpu<int,1>& tilted_path_bounds,
+        const Array_gpu<Float,1>& p_lev_tilt,
+        const Array_gpu<Float,2>& sw_flux_dn_tilt, const Array_gpu<Float,2>& sw_flux_dn_dir_tilt,
+        const Array_gpu<Float,2>& sw_flux_up_tilt, const Array_gpu<Float,2>& sw_flux_net_tilt,
+        const Array_gpu<Float,3>& rt_flux_abs_dir_tilt, const Array_gpu<Float,3>& rt_flux_abs_dif_tilt, const Array_gpu<Float,2>& rt_flux_tod_up_tilt,
+        Array_gpu<Float,2>& sw_flux_dn, Array_gpu<Float,2>& sw_flux_dn_dir,
+        Array_gpu<Float,2>& sw_flux_up, Array_gpu<Float,2>& sw_flux_net,
+        Array_gpu<Float,3>& rt_flux_abs_dir, Array_gpu<Float,3>& rt_flux_abs_dif, Array_gpu<Float,2>& rt_flux_tod_up)
+{
+    const int n_zh_tilted = zh_tilt.size();
+    const int n_col = n_col_x * n_col_y;
+    const int block_col_x = 8;
+    const int block_col_y = 8;
+    const int block_lev = 4;
+    const int block_z   = 4;
+
+    const int grid_col_x = n_col_x/block_col_x + (n_col_x%block_col_x > 0);
+    const int grid_col_y = n_col_y/block_col_y + (n_col_y%block_col_y > 0);
+    const int grid_lev = n_lev/block_lev + (n_lev%block_lev > 0);
+    const int grid_z   = n_z/block_z + (n_z%block_z > 0);
+
+    dim3 grid_3d_lev(grid_col_x, grid_col_y, grid_lev);
+    dim3 block_3d_lev(block_col_x, block_col_y, block_lev);
+
+    dim3 grid_3d_z(grid_col_x, grid_col_y, grid_z);
+    dim3 block_3d_z(block_col_x, block_col_y, block_z);
+
+    dim3 grid_2d(grid_col_x, grid_col_y, 1);
+    dim3 block_2d(block_col_x, block_col_y, 1);
+
+    if (do_tilting)
+    {
+        if (switch_twostream)
+        {
+            sw_flux_dn.set_dims({n_col, n_lev});
+            sw_flux_dn_dir.set_dims({n_col, n_lev});
+            sw_flux_up.set_dims({n_col, n_lev});
+            sw_flux_net.set_dims({n_col, n_lev});
+
+            translate_twostream_fluxes_gpu<<<grid_3d_lev, block_3d_lev>>>(
+                    n_col_x, n_col_y, n_z_in, n_lev,
+                    tilted_path.ptr(), tilted_path_bounds.ptr(),
+                    sw_flux_dn_tilt.ptr(), sw_flux_dn.ptr());
+            translate_twostream_fluxes_gpu<<<grid_3d_lev, block_3d_lev>>>(
+                    n_col_x, n_col_y, n_z_in, n_lev,
+                    tilted_path.ptr(), tilted_path_bounds.ptr(),
+                    sw_flux_dn_dir_tilt.ptr(), sw_flux_dn_dir.ptr());
+            translate_twostream_fluxes_gpu<<<grid_3d_lev, block_3d_lev>>>(
+                    n_col_x, n_col_y, n_z_in, n_lev,
+                    tilted_path.ptr(), tilted_path_bounds.ptr(),
+                    sw_flux_up_tilt.ptr(), sw_flux_up.ptr());
+            translate_twostream_fluxes_gpu<<<grid_3d_lev, block_3d_lev>>>(
+                    n_col_x, n_col_y, n_z_in, n_lev,
+                    tilted_path.ptr(), tilted_path_bounds.ptr(),
+                    sw_flux_net_tilt.ptr(), sw_flux_net.ptr());
+        }
+
+        if (switch_raytracing)
+        {
+            rt_flux_abs_dir.set_dims({n_col_x, n_col_y, n_z});
+            rt_flux_abs_dif.set_dims({n_col_x, n_col_y, n_z});
+            rt_flux_tod_up.set_dims({n_col_x, n_col_y});
+
+            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_col_x, n_col_y, n_z, rt_flux_abs_dir.ptr());
+            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_col_x, n_col_y, n_z, rt_flux_abs_dif.ptr());
+
+            translate_absorption_gpu<<<grid_3d_z, block_3d_z>>>(
+                    n_col_x, n_col_y, n_z_in, n_z,
+                    tilted_path.ptr(),
+                    tilted_path_bounds.ptr(),
+                    p_lev_tilt.ptr(),
+                    rt_flux_abs_dir_tilt.ptr(),
+                    rt_flux_abs_dir.ptr());
+
+            translate_absorption_gpu<<<grid_3d_z, block_3d_z>>>(
+                    n_col_x, n_col_y, n_z_in, n_z,
+                    tilted_path.ptr(),
+                    tilted_path_bounds.ptr(),
+                    p_lev_tilt.ptr(),
+                    rt_flux_abs_dif_tilt.ptr(),
+                    rt_flux_abs_dif.ptr());
+
+            translate_toa_flux_gpu<<<grid_2d, block_2d>>>(
+                    n_col_x, n_col_y, n_zh_tilted,
+                    tilted_path.ptr(),
+                    tilted_path_bounds.ptr(),
+                    rt_flux_tod_up_tilt.ptr(),
+                    rt_flux_tod_up.ptr());
+        }
+    }
+    else
+    {
+        Array_gpu<Float,1> mean_profile({n_lev});
+        const Float n_col_inv = Float(1.) / (n_col_x * n_col_y);
+
+        if (switch_twostream)
+        {
+            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_lev, mean_profile.ptr());
+
+            tica_mean_profile<<<grid_3d_lev, block_3d_lev>>>(
+                    n_col_x, n_col_y, n_lev, n_col_inv,
+                    sw_flux_dn_tilt.ptr(), mean_profile.ptr());
+
+            tica_profile_to_3d<<<grid_3d_lev, block_3d_lev>>>(
+                    n_col_x, n_col_y, n_lev, n_col_inv,
+                    mean_profile.ptr(), sw_flux_dn.ptr());
+
+            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_lev, mean_profile.ptr());
+
+            tica_mean_profile<<<grid_3d_lev, block_3d_lev>>>(
+                    n_col_x, n_col_y, n_lev, n_col_inv,
+                    sw_flux_dn_dir_tilt.ptr(), mean_profile.ptr());
+
+            tica_profile_to_3d<<<grid_3d_lev, block_3d_lev>>>(
+                    n_col_x, n_col_y, n_lev, n_col_inv,
+                    mean_profile.ptr(), sw_flux_dn_dir.ptr());
+
+            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_lev, mean_profile.ptr());
+
+            tica_mean_profile<<<grid_3d_lev, block_3d_lev>>>(
+                    n_col_x, n_col_y, n_lev, n_col_inv,
+                    sw_flux_up_tilt.ptr(), mean_profile.ptr());
+
+            tica_profile_to_3d<<<grid_3d_lev, block_3d_lev>>>(
+                    n_col_x, n_col_y, n_lev, n_col_inv,
+                    mean_profile.ptr(), sw_flux_up.ptr());
+
+            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_lev, mean_profile.ptr());
+
+            tica_mean_profile<<<grid_3d_lev, block_3d_lev>>>(
+                    n_col_x, n_col_y, n_lev, n_col_inv,
+                    sw_flux_net.ptr(), mean_profile.ptr());
+
+            tica_profile_to_3d<<<grid_3d_lev, block_3d_lev>>>(
+                    n_col_x, n_col_y, n_lev, n_col_inv,
+                    mean_profile.ptr(), sw_flux_net.ptr());
+        }
+        if (switch_raytracing)
+        {
+            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_lev, mean_profile.ptr());
+
+            tica_mean_profile<<<grid_3d_z, block_3d_z>>>(
+                    n_col_x, n_col_y, n_z, n_col_inv,
+                    rt_flux_abs_dir.ptr(), mean_profile.ptr());
+
+            tica_profile_to_3d<<<grid_3d_z, block_3d_z>>>(
+                    n_col_x, n_col_y, n_z, n_col_inv,
+                    mean_profile.ptr(), rt_flux_abs_dir.ptr());
+
+            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_lev, mean_profile.ptr());
+
+            tica_mean_profile<<<grid_3d_z, block_3d_z>>>(
+                    n_col_x, n_col_y, n_z, n_col_inv,
+                    rt_flux_abs_dif.ptr(), mean_profile.ptr());
+
+            tica_profile_to_3d<<<grid_3d_z, block_3d_z>>>(
+                    n_col_x, n_col_y, n_z, n_col_inv,
+                    mean_profile.ptr(), rt_flux_abs_dif.ptr());
+
+
+            Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(n_lev, mean_profile.ptr());
+
+            tica_mean_profile<<<grid_2d, block_2d>>>(
+                    n_col_x, n_col_y, 1, n_col_inv,
+                    rt_flux_tod_up.ptr(), mean_profile.ptr());
+
+            tica_profile_to_3d<<<grid_2d, block_2d>>>(
+                    n_col_x, n_col_y, 1, n_col_inv,
+                    mean_profile.ptr(), rt_flux_tod_up.ptr());
+        }
+    }
+}
+
 

--- a/src_tilt/tilt_utils.cu
+++ b/src_tilt/tilt_utils.cu
@@ -276,13 +276,13 @@ namespace
         {
             const int idx  = ix + iy*n_y + iz*n_y*n_x;
 
-            const Float qsat = t_lay[idx] > Float(273.16) ? qsat_liq(p_lay[idx], t_lay[idx]) : qsat_ice(p_lay[idx], t_lay[idx]);
+            const Float qsat = t_lay[idx] > Float(273.15) ? qsat_liq(p_lay[idx], t_lay[idx]) : qsat_ice(p_lay[idx], t_lay[idx]);
 
             constexpr Float eps = Float(0.62185985592);
 
             const Float q = h2o_vmr[idx] * eps / (1 + h2o_vmr[idx] * eps);
 
-            rh[idx] = q / qsat;
+            rh[idx] = min(max(Float(0.), q / qsat), Float(1.));
 
         }
     }
@@ -336,7 +336,7 @@ void tica_tilt_gpu(
     center_zh_tilt.set_dims({n_zh_tilt_center});
 
     Array<int,1> center_path_bounds({n_zh_in});
-    get_tilted_path_bounds(n_z_tilt_center, center_path.v(), center_path_bounds.v());
+    get_tilted_path_bounds(n_zh_tilt_center, center_path.v(), center_path_bounds.v());
 
     Array_gpu<ijk,1> center_path_gpu(center_path);
     Array_gpu<Float,1> center_zh_tilt_gpu(center_zh_tilt);
@@ -394,10 +394,10 @@ void tica_tilt_gpu(
         t_lay_tilt.ptr(), p_lev_tilt.ptr(),
         t_lay.ptr());
 
+    t_lay.dump("t_lay");
 
     //// tilt and compress gasses ////
     Array_gpu<Float,2> gas_tilt({n_col, n_z_tilt_center});
-    Array_gpu<Float,2> gas_new({n_col, n_z_in});
 
     for (const auto& gas_name : gas_names)
     {
@@ -406,7 +406,7 @@ void tica_tilt_gpu(
             continue;
         }
 
-        const Array_gpu<Float,2>& gas = gas_concs.get_vmr(gas_name);
+        Array_gpu<Float,2> gas(gas_concs.get_vmr(gas_name));
         if (gas.size() > 1)
         {
             if (gas.get_dims()[0] > 1)
@@ -420,9 +420,10 @@ void tica_tilt_gpu(
                         n_col_x, n_col_y, n_z_in,
                         center_path_bounds_gpu.ptr(),
                         gas_tilt.ptr(), p_lev_tilt.ptr(),
-                        gas_new.ptr());
+                        gas.ptr());
 
-                gas_concs.set_vmr(gas_name, gas_new);
+                gas_concs.set_vmr(gas_name, gas);
+
             }
             else
             {
@@ -434,7 +435,7 @@ void tica_tilt_gpu(
                         n_col_x, n_col_y, n_z_in,
                         t_lay.ptr(),
                         p_lay.ptr(),
-                        gas_new.ptr(),
+                        gas.ptr(),
                         rh.ptr());
             }
         }
@@ -443,7 +444,7 @@ void tica_tilt_gpu(
     if (switch_aerosol_optics)
     {
         Array_gpu<Float,2> aerosol_tilt({n_col, n_z_tilt_center});
-        Array_gpu<Float,2> aerosol_new({n_col, n_z_in});
+        //Array_gpu<Float,2> aerosol_new({n_col, n_z_in});
 
         for (const auto& aerosol_name : aerosol_names)
         {
@@ -452,7 +453,7 @@ void tica_tilt_gpu(
                 continue;
             }
 
-            const Array_gpu<Float,2>& aerosol = aerosol_concs.get_vmr(aerosol_name);
+            Array_gpu<Float,2> aerosol(aerosol_concs.get_vmr(aerosol_name));
             if (aerosol.size() > 1)
             {
                 if (aerosol.get_dims()[0] > 1)
@@ -466,9 +467,9 @@ void tica_tilt_gpu(
                             n_col_x, n_col_y, n_z_in,
                             center_path_bounds_gpu.ptr(),
                             aerosol_tilt.ptr(), p_lev_tilt.ptr(),
-                            aerosol_new.ptr());
+                            aerosol.ptr());
 
-                    aerosol_concs.set_vmr(aerosol_name, aerosol_new);
+                    aerosol_concs.set_vmr(aerosol_name, aerosol);
                 }
                 else
                 {


### PR DESCRIPTION
Fully working GPU version of tilted colums, including "reverse"  tilt to get TICA fluxes back on original grid. Currently, tica-gpu is only implemented in the ray tracer executable (test_rte_rrtmgp_rt.cu), but in future work it should also be used in test_rte_rrtmgp.cu. Next step though is coupling to MicroHH.